### PR TITLE
Summary field implemented for commentary fields

### DIFF
--- a/Angular/src/app/app.component.scss
+++ b/Angular/src/app/app.component.scss
@@ -172,3 +172,9 @@ span.mat-button-focus-overlay {
   max-width: 100%;
   /* width: 100%; */
 }
+
+/* Creates an outline, with a padding based on a summary block */
+.summary {
+  outline: 1px solid black;
+  padding: 5px;
+}

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -217,7 +217,7 @@ export class FragmentsComponent implements OnInit, OnDestroy {
         };
         current_fragment.lines[item] = updated_lines;
       }
-      // replaces the summary tag with summary CSS for each commentary field
+      // replaces the summary tag with summary CSS class for each commentary field
       current_fragment.apparatus = this.convert_summary_tag_to_html(current_fragment.apparatus);
       current_fragment.differences = this.convert_summary_tag_to_html(current_fragment.differences);
       current_fragment.translation = this.convert_summary_tag_to_html(current_fragment.translation);

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -209,6 +209,11 @@ export class FragmentsComponent implements OnInit, OnDestroy {
     for (const fragment in array) {
       // Loop through all fragments
       const current_fragment = array[fragment];
+      // replaces the summary tag with summary CSS
+      current_fragment.apparatus = current_fragment.apparatus.replace(
+        /\[summary\]([\s\S]*?)\[\/summary\]/gm,
+        '<div class="summary">$1</div>'
+      );
       for (const item in current_fragment.lines) {
         // Loop through all lines of current fragment
         let line_text = current_fragment.lines[item].text;

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -1,12 +1,8 @@
 // Library imports
 import { Component, OnInit, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { Output, EventEmitter } from '@angular/core';
-//import { MatDialog } from '@angular/material/dialog'; // Library used for interacting with the page
 import { trigger, transition, style, animate } from '@angular/animations';
 //import { environment } from '@src/environments/environment';
-
-// Component imports
-//import { LoginComponent } from '@oscc/login/login.component';
 
 // Service imports
 import { ApiService } from '@oscc/api.service';
@@ -203,17 +199,13 @@ export class FragmentsComponent implements OnInit, OnDestroy {
    * @param array with fragments as retrieved from the server
    * @returns updated array with nice HTML formatting included
    * @author Ycreak
+   * @TODO: this function needs to be handled by the API when retrieving the fragments
    */
   public add_HTML_to_lines(array: Fragment[]): Fragment[] {
     // For each element in the given array
     for (const fragment in array) {
       // Loop through all fragments
       const current_fragment = array[fragment];
-      // replaces the summary tag with summary CSS
-      current_fragment.apparatus = current_fragment.apparatus.replace(
-        /\[summary\]([\s\S]*?)\[\/summary\]/gm,
-        '<div class="summary">$1</div>'
-      );
       for (const item in current_fragment.lines) {
         // Loop through all lines of current fragment
         let line_text = current_fragment.lines[item].text;
@@ -225,8 +217,24 @@ export class FragmentsComponent implements OnInit, OnDestroy {
         };
         current_fragment.lines[item] = updated_lines;
       }
+      // replaces the summary tag with summary CSS for each commentary field
+      current_fragment.apparatus = this.convert_summary_tag_to_html(current_fragment.apparatus);
+      current_fragment.differences = this.convert_summary_tag_to_html(current_fragment.differences);
+      current_fragment.translation = this.convert_summary_tag_to_html(current_fragment.translation);
+      current_fragment.commentary = this.convert_summary_tag_to_html(current_fragment.commentary);
+      current_fragment.reconstruction = this.convert_summary_tag_to_html(current_fragment.reconstruction);
     }
     return array;
+  }
+
+  /**
+   * Converts the summary tag in the given blob of text to html
+   * @param string with text blob possibly containing the summary tag
+   * @returns string with the summary tag replaced with corresponding html
+   * @author Ycreak
+   */
+  private convert_summary_tag_to_html(given_string: string): string {
+    return given_string.replace(/\[summary\]([\s\S]*?)\[\/summary\]/gm, '<div class="summary">$1</div>');
   }
 
   /**


### PR DESCRIPTION
This update allows the user to add small summaries to the commentary fields. Because it is a work in progress awaiting approval from the team, the implementation is clunky at best :)

**Functional tests**
- [x] Go to the dashboard, select Ennius Thyestes 134, go to reconstruction and add the following: `[summary] hello there, this is a a summary test [/summary]`. Now go to the fragments and see if the reconstruction field of Ennius Thyestes 134 has a summary shown inside a black box.