### PR TITLE
Dashboard properly cleared when retrieving new data

### DIFF
--- a/Angular/src/app/api.service.ts
+++ b/Angular/src/app/api.service.ts
@@ -72,10 +72,10 @@ export class ApiService {
   public new_titles_alert = new ReplaySubject(0);
   public new_editors_alert = new ReplaySubject(0);
 
-  private new_fragments_alert = new BehaviorSubject<number>(0);
+  private new_fragments_alert = new BehaviorSubject<number>(-1);
   public new_fragments_alert$ = this.new_fragments_alert.asObservable();
 
-  private new_fragment_names_alert = new BehaviorSubject<number>(0);
+  private new_fragment_names_alert = new BehaviorSubject<number>(-1);
   public new_fragment_names_alert$ = this.new_fragment_names_alert.asObservable();
 
   private create_fragment_key(author?: string, title?: string, editor?: string, name?: string): fragment_key {

--- a/Angular/src/app/dashboard/dashboard.component.ts
+++ b/Angular/src/app/dashboard/dashboard.component.ts
@@ -173,6 +173,7 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
     /** Handle what happens when new fragments arrive */
     this.fragments_subscription = this.api.new_fragments_alert$.subscribe((column_id) => {
       if (column_id == environment.dashboard_id) {
+        this.reset_fragment_form();
         this.convert_Fragment_to_fragment_form(this.api.fragments[0]);
         // Set the data for the drop down menus
         this.selected_fragment_data.author = this.fragment_form.value.author;

--- a/Angular/src/app/dashboard/dashboard.component.ts
+++ b/Angular/src/app/dashboard/dashboard.component.ts
@@ -440,7 +440,7 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
   protected reset_fragment_form(): void {
     // First, remove all data from the form
     this.fragment_form.reset();
-    // Second, remove the controls created for the FormArrays
+    // Second, remove the previously created FormArray controls and set new ones
     this.fragment_form.setControl('context', new FormArray([]));
     this.fragment_form.setControl('lines', new FormArray([]));
     this.fragment_form.setControl('linked_fragments', new FormArray([]));

--- a/Angular/src/app/overview/overview.component.ts
+++ b/Angular/src/app/overview/overview.component.ts
@@ -104,8 +104,8 @@ export class OverviewComponent implements OnInit, OnDestroy {
    * Function to handle the login dialog
    * @author Ycreak
    */
-  public login(): void {
-    const dialogRef = this.matdialog.open(LoginComponent, {});
+  protected login(): void {
+    this.matdialog.open(LoginComponent, {});
   }
 
   /**

--- a/Angular/src/app/playground/playground.component.ts
+++ b/Angular/src/app/playground/playground.component.ts
@@ -108,13 +108,17 @@ export class PlaygroundComponent implements OnInit, OnDestroy, AfterViewInit {
       const object_index = column.fragments.findIndex((object) => {
         return object._id === column.clicked_fragment._id;
       });
-      column.fragments.splice(object_index, 1);
+      if (object_index != -1) {
+        column.fragments.splice(object_index, 1);
+      }
     } else {
       // it is a note
       const object_index = column.note_array.findIndex((object) => {
         return object === column.clicked_note;
       });
-      column.note_array.splice(object_index, 1);
+      if (object_index != -1) {
+        column.note_array.splice(object_index, 1);
+      }
     }
   }
 

--- a/Angular/src/app/services/dialog.service.ts
+++ b/Angular/src/app/services/dialog.service.ts
@@ -17,7 +17,7 @@ export class DialogService {
    * @author Ycreak
    */
   public open_about_dialog(): void {
-    const dialogRef = this.dialog.open(ShowAboutDialogComponent, {
+    this.dialog.open(ShowAboutDialogComponent, {
       autoFocus: false, // To allow scrolling in the dialog
       maxHeight: '90vh', //you can adjust the value as per your view
     });
@@ -79,7 +79,7 @@ export class DialogService {
    * @author Ycreak
    */
   public open_custom_dialog(content): void {
-    const dialogRef = this.dialog.open(CustomDialogComponent, {
+    this.dialog.open(CustomDialogComponent, {
       width: '90%',
       height: '75%',
       data: {

--- a/Angular/src/app/utility.service.ts
+++ b/Angular/src/app/utility.service.ts
@@ -149,8 +149,8 @@ export class UtilityService {
    * @returns new array with item popped
    * @author Ycreak
    */
-  public pop_array(array) {
-    const _ = array.pop();
+  public pop_array(array: any) {
+    array.pop();
     return array;
   }
 


### PR DESCRIPTION
This PR ensures that the dashboard is properly cleared when new data is requested. No more lingering context or fragment lines.

**Functional tests**

- [x] In the dashboard, load Ennius Thyestes TRF 134. Go to the context tab. Now load Ennius Thyestes TRF 132: see that only one context field remains, instead of five like before.