### PR TITLE
Linked fragments now found via soft key

### DIFF
--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -118,7 +118,7 @@ export class FragmentsComponent implements OnInit, OnDestroy {
     // Second, colour the clicked fragment
     fragment.colour = '#3F51B5';
     // Lastly, colour the linked fragments
-    this.colour_linked_fragments(fragment);
+    this.column_handler.colour_linked_fragments(fragment);
     // And scroll each column to the linked fragment if requested
     if (this.settings.fragments.auto_scroll_linked_fragments) {
       this.scroll_to_linked_fragments(fragment);
@@ -147,33 +147,6 @@ export class FragmentsComponent implements OnInit, OnDestroy {
           element.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
         }
       }
-    }
-  }
-
-  /**
-   * Given the current fragment, colour the linked fragments in the other columns
-   * @param fragment of which the linked fragments should be coloured
-   * @author Ycreak
-   */
-  private colour_linked_fragments(fragment: Fragment): void {
-    // Loop through all fragments the linked fragments
-    for (const i in fragment.linked_fragments) {
-      const linked_fragment_id = fragment.linked_fragments[i].linked_fragment_id;
-      // Now, for each fragment that is linked, try to find it in the other columns
-      for (const j in this.column_handler.columns) {
-        // in each column, take a look in the fragments array to find the linked fragment
-        const corresponding_fragment = this.column_handler.columns[j].fragments.find(
-          (i) => i._id === linked_fragment_id
-        );
-        // colour it if found
-        if (corresponding_fragment) corresponding_fragment.colour = '#FF4081';
-      }
-      // Do the same for the playground TODO:
-      //const corresponding_fragment = this.playground_handler.playground.fragments.find(
-      //(i) => i._id === linked_fragment_id
-      //);
-      // colour it if found
-      //if (corresponding_fragment) corresponding_fragment.colour = '#FF4081';
     }
   }
 

--- a/Angular/src/app/services/column-handler.service.ts
+++ b/Angular/src/app/services/column-handler.service.ts
@@ -4,6 +4,7 @@
 import { Injectable } from '@angular/core';
 
 import { Column } from '@oscc/models/Column';
+import { Fragment } from '@oscc/models/Fragment';
 
 import { ApiService } from '@oscc/api.service';
 import { UtilityService } from '@oscc/utility.service';
@@ -115,5 +116,40 @@ export class ColumnHandlerService {
       connected_columns_list.push(String(i.column_id));
     }
     return connected_columns_list;
+  }
+
+  /**
+   * Given the current fragment, colour the linked fragments in the other columns
+   * @param fragment of which the linked fragments should be coloured
+   * @author Ycreak
+   */
+  public colour_linked_fragments(fragment: Fragment): void {
+    // Loop through all fragments the linked fragments
+    for (const i in fragment.linked_fragments) {
+      const author = fragment.linked_fragments[i].author;
+      const title = fragment.linked_fragments[i].title;
+      const editor = fragment.linked_fragments[i].editor;
+      const name = fragment.linked_fragments[i].name;
+      // Now, for each fragment that is linked, try to find it in the other columns
+      for (const j in this.columns) {
+        // in each column, take a look in the fragments array to find the linked fragment
+        const corresponding_fragment = this.utility.filter_array_on_object(this.columns[j].fragments, {
+          author: author,
+          title: title,
+          editor: editor,
+          name: name,
+        });
+
+        if (corresponding_fragment?.length) {
+          corresponding_fragment[0].colour = '#FF4081';
+        }
+      }
+      // Do the same for the playground TODO:
+      //const corresponding_fragment = this.playground_handler.playground.fragments.find(
+      //(i) => i._id === linked_fragment_id
+      //);
+      // colour it if found
+      //if (corresponding_fragment) corresponding_fragment.colour = '#FF4081';
+    }
   }
 }

--- a/Angular/src/app/utility.service.ts
+++ b/Angular/src/app/utility.service.ts
@@ -196,4 +196,18 @@ export class UtilityService {
     console.log(thing);
     console.log('############ ####### ############');
   }
+
+  /**
+   * Searches an array of objects based on the given object as filter. Returns all objects
+   * that fit the filter description.
+   * @param array of objects that needs filtering
+   * @param search_object that functions as filter
+   * @return array with objects based on filter
+   * @author Ycreak
+   */
+  public filter_array_on_object(array: any, search_object: any) {
+    return array.filter((el: any) => {
+      return Object.entries(search_object).every(([key, value]) => String(el[key]).includes(String(value)));
+    });
+  }
 }


### PR DESCRIPTION
Linked fragments in columns are now found via the softkey author-title-editor-name instead of the fragment id. This solves linking problems in the dashboard.

**Functional tests**
- [x] Open a second column with Ennius - Thyestes - Jocelyn. Check if fragments are linked by clicking them. For example, TRF 132 should be linked to Jocelyn 150.
- [x] Also check with three columns, for example including Ennius - Thyestes - Warmington.