### PR TITLE
Sajvanwijk/issue131

### DIFF
--- a/Angular/src/app/_mixins.scss
+++ b/Angular/src/app/_mixins.scss
@@ -1,9 +1,23 @@
 $theme-primary: #3f51b5;
 $theme-secondary: #ff4081;
 
-@mixin button-dashed-background {
+@mixin button-dashed-background-yellow {
   background-position: 10px 0, 10px 0, 0 0, 0 0;
   background-repeat: repeat;
   background: repeating-linear-gradient(-65deg, #fff7e0, #fff7e0 12px, #ffffff 5px, #ffffff 25px);
+  border-color: rgba(0, 0, 0, 0.12);
+}
+
+@mixin button-dashed-background-red {
+  background-position: 10px 0, 10px 0, 0 0, 0 0;
+  background-repeat: repeat;
+  background: repeating-linear-gradient(-65deg, #fff2f2, #fff2f2 12px, #ffffff 5px, #ffffff 25px);
+  border-color: rgba(0, 0, 0, 0.12);
+}
+
+@mixin button-dashed-background-gray {
+  background-position: 10px 0, 10px 0, 0 0, 0 0;
+  background-repeat: repeat;
+  background: repeating-linear-gradient(-65deg, #f8f8f8, #f8f8f8 12px, #ffffff 5px, #ffffff 25px);
   border-color: rgba(0, 0, 0, 0.12);
 }

--- a/Angular/src/app/_mixins.scss
+++ b/Angular/src/app/_mixins.scss
@@ -1,0 +1,9 @@
+$theme-primary: #3f51b5;
+$theme-secondary: #ff4081;
+
+@mixin button-dashed-background {
+  background-position: 10px 0, 10px 0, 0 0, 0 0;
+  background-repeat: repeat;
+  background: repeating-linear-gradient(-65deg, #fff7e0, #fff7e0 12px, #ffffff 5px, #ffffff 25px);
+  border-color: rgba(0, 0, 0, 0.12);
+}

--- a/Angular/src/app/api.service.ts
+++ b/Angular/src/app/api.service.ts
@@ -469,6 +469,7 @@ export class ApiService {
       responseType: 'text' as 'json',
     });
   }
+  // Introduction
   public get_introduction_text(intro: Introduction_form): Observable<any> {
     return this.http.post<any>(this.FlaskURL + 'introduction/get_introduction_text', intro, {
       observe: 'body',
@@ -505,6 +506,25 @@ export class ApiService {
       observe: 'response',
       responseType: 'text' as 'json',
     });
+  }
+  // Bibliography
+  public get_bibliography_authors(): Observable<any> {
+    return; // TODO
+  }
+  public get_bibliography_from_author(author: string): Observable<any> {
+    return; // TODO
+  }
+  public get_bibliography_from_id(id): Observable<any> {
+    return; // TODO
+  }
+  public revise_bibliography_entry(bibliography): Observable<any> {
+    return; // TODO
+  }
+  public create_bibliography_entry(bibliography): Observable<any> {
+    return; // TODO
+  }
+  public delete_bibliography_entry(id): Observable<any> {
+    return; // TODO
   }
   // Neural networks part
   public scan_lines(lines: object): Observable<any> {

--- a/Angular/src/app/app.module.ts
+++ b/Angular/src/app/app.module.ts
@@ -87,6 +87,7 @@ import { PlaygroundComponent } from './playground/playground.component';
 import { CommentaryComponent } from './commentary/commentary.component';
 import { OverviewComponent } from './overview/overview.component';
 import { IntroductionsComponent } from './dashboard/introductions/introductions.component';
+import { BibliographyComponent } from './dashboard/bibliography/bibliography.component';
 
 // Routes to take. Disallows Path Traversal.
 const appRoutes: Routes = [
@@ -115,6 +116,7 @@ const appRoutes: Routes = [
     CommentaryComponent,
     OverviewComponent,
     IntroductionsComponent,
+    BibliographyComponent,
   ],
   imports: [
     BrowserModule,

--- a/Angular/src/app/dashboard/bibliography/bibliography.component.html
+++ b/Angular/src/app/dashboard/bibliography/bibliography.component.html
@@ -1,0 +1,170 @@
+<!-- BIBLIOGRAPHY PANEL -->
+<mat-expansion-panel *ngIf="this.auth_service.is_logged_in" [expanded]="true">
+  <mat-expansion-panel-header>
+    <mat-panel-title> Change bibliography data </mat-panel-title>
+    <mat-panel-description>
+      Create, revise and delete bibliography entries.
+      <mat-icon>auto_stories</mat-icon>
+    </mat-panel-description>
+  </mat-expansion-panel-header>
+
+  <div class="alert alert-info" role="alert">
+    The OSCC has a build-in bibliography management system which is accessible to all users. Select the tab appropriate
+    for your title and fill in all fields (without HTML formatting). It can then be linked to a fragment using the
+    <b>Change fragment data</b> panel. If you want to revise a source, use the Author search field below to find it in
+    the database. Make sure you are in the correct tab before pressing the revise button.
+  </div>
+
+  <!-- Buttons to submit fragment data -->
+  <button
+    mat-stroked-button
+    color="primary"
+    [disabled]="!bibliography_form.valid"
+    (click)="request_create_bibliography_entry(this.bibliography_form.value)"
+    *ngIf="this.auth_service.current_user_role === 'teacher' || this.auth_service.is_student">
+    Create bibliography entry
+  </button>
+  <button
+    mat-stroked-button
+    color="primary"
+    [disabled]="!bibliography_form.valid"
+    (click)="request_revise_bibliography_entry(this.bibliography_form.value)"
+    *ngIf="this.auth_service.current_user_role === 'teacher' || this.auth_service.is_student">
+    Revise bibliography entry
+  </button>
+  <button
+    mat-stroked-button
+    color="warn"
+    [disabled]="!bib_entry_selected"
+    (click)="request_delete_bibliography_entry(this.bibliography_form.value)"
+    *ngIf="this.auth_service.current_user_role === 'teacher'">
+    Delete bibliography entry
+  </button>
+  <hr />
+
+  <!-- Find the name of your author -->
+  <form class="example-form">
+    <mat-form-field class="example-full-width" appearance="fill">
+      <mat-label>Search an Author</mat-label>
+      <input
+        type="text"
+        placeholder="Type author name"
+        aria-label="Author"
+        matInput
+        [formControl]="bibliography_author_selection_form"
+        [matAutocomplete]="auto" />
+      <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
+        <mat-option
+          *ngFor="let option of bibliography_author_selection_form_filtered_options | async"
+          [value]="option"
+          (click)="this.request_bibliography_from_author(option)">
+          {{ option }}
+        </mat-option>
+      </mat-autocomplete>
+      <mat-hint>Search for title to revise</mat-hint>
+    </mat-form-field>
+  </form>
+
+  <mat-selection-list [multiple]="false">
+    <mat-list-option
+      *ngFor="let bib_entry of retrieved_author_bibliography"
+      [value]="bib_entry"
+      (click)="this.handle_bib_entry_selection(bib_entry)"
+      (click)="this.bib_entry_selected = true">
+      {{ bib_entry.author }}, {{ bib_entry.title }}, {{ bib_entry.year }}
+    </mat-list-option>
+  </mat-selection-list>
+
+  <hr />
+
+  <mat-tab-group
+    [selectedIndex]="bibliography_form_selected_type.value"
+    (selectedTabChange)="on_bibliography_tab_change($event)">
+    <form [formGroup]="bibliography_form">
+      <mat-tab label="Book"
+        ><br />
+
+        <mat-form-field class="input-form-half">
+          <mat-label>Author</mat-label>
+          <input matInput type="text" formControlName="author" />
+          <!--required> TODO:?-->
+        </mat-form-field>
+
+        <mat-form-field class="input-form-half">
+          <mat-label>Title</mat-label>
+          <input matInput type="text" formControlName="title" />
+          <!--required> -->
+        </mat-form-field>
+
+        <mat-form-field class="input-form-half">
+          <mat-label>Year</mat-label>
+          <input matInput type="text" formControlName="year" />
+          <!--required> -->
+        </mat-form-field>
+
+        <mat-form-field class="input-form-half">
+          <mat-label>Series</mat-label>
+          <input matInput type="text" formControlName="series" />
+          <!--required> -->
+        </mat-form-field>
+
+        <mat-form-field class="input-form-half">
+          <mat-label>Number</mat-label>
+          <input matInput type="text" formControlName="number" />
+          <!--required> -->
+        </mat-form-field>
+
+        <mat-form-field class="input-form-half">
+          <mat-label>Location</mat-label>
+          <input matInput type="text" formControlName="location" />
+          <!--required> -->
+        </mat-form-field>
+
+        <mat-form-field class="input-form-half">
+          <mat-label>Edition</mat-label>
+          <input matInput type="text" formControlName="edition" />
+          <!--required> -->
+        </mat-form-field>
+      </mat-tab>
+
+      <mat-tab label="Article"
+        ><br />
+        <mat-form-field class="input-form-half">
+          <mat-label>Author</mat-label>
+          <input matInput type="text" formControlName="author" />
+          <!--required> -->
+        </mat-form-field>
+
+        <mat-form-field class="input-form-half">
+          <mat-label>Title</mat-label>
+          <input matInput type="text" formControlName="title" />
+          <!--required> -->
+        </mat-form-field>
+
+        <mat-form-field class="input-form-half">
+          <mat-label>Year</mat-label>
+          <input matInput type="text" formControlName="year" />
+          <!--required> -->
+        </mat-form-field>
+
+        <mat-form-field class="input-form-half">
+          <mat-label>Journal</mat-label>
+          <input matInput type="text" formControlName="journal" />
+          <!--required> -->
+        </mat-form-field>
+
+        <mat-form-field class="input-form-half">
+          <mat-label>Volume</mat-label>
+          <input matInput type="text" formControlName="volume" />
+          <!--required> -->
+        </mat-form-field>
+
+        <mat-form-field class="input-form-half">
+          <mat-label>Pages</mat-label>
+          <input matInput type="text" formControlName="pages" />
+          <!--required> -->
+        </mat-form-field>
+      </mat-tab>
+    </form>
+  </mat-tab-group>
+</mat-expansion-panel>

--- a/Angular/src/app/dashboard/bibliography/bibliography.component.html
+++ b/Angular/src/app/dashboard/bibliography/bibliography.component.html
@@ -18,6 +18,8 @@
   <!-- Buttons to submit fragment data -->
   <button
     mat-stroked-button
+    class="bibliography-button"
+    id="create-bibliography-button"
     color="primary"
     [disabled]="!bibliography_form.valid"
     (click)="request_create_bibliography_entry(this.bibliography_form.value)"
@@ -26,6 +28,8 @@
   </button>
   <button
     mat-stroked-button
+    class="bibliography-button"
+    id="revise-bibliography-button"
     color="primary"
     [disabled]="!bibliography_form.valid"
     (click)="request_revise_bibliography_entry(this.bibliography_form.value)"
@@ -34,6 +38,8 @@
   </button>
   <button
     mat-stroked-button
+    class="bibliography-button"
+    id="delete-bibliography-button"
     color="warn"
     [disabled]="!bib_entry_selected"
     (click)="request_delete_bibliography_entry(this.bibliography_form.value)"

--- a/Angular/src/app/dashboard/bibliography/bibliography.component.scss
+++ b/Angular/src/app/dashboard/bibliography/bibliography.component.scss
@@ -1,0 +1,1 @@
+@import url("../dashboard.component.scss");

--- a/Angular/src/app/dashboard/bibliography/bibliography.component.scss
+++ b/Angular/src/app/dashboard/bibliography/bibliography.component.scss
@@ -12,12 +12,10 @@
 }
 
 #delete-bibliography-button:enabled {
-  @include button-dashed-background;
-  background: repeating-linear-gradient(-65deg, #fff2f2, #fff2f2 12px, #ffffff 5px, #ffffff 25px);
+  @include button-dashed-background-red;
 }
 
 #delete-bibliography-button:disabled {
-  @include button-dashed-background;
-  background: repeating-linear-gradient(-65deg, #f8f8f8, #f8f8f8 12px, #ffffff 5px, #ffffff 25px);
+  @include button-dashed-background-gray;
   color: darkgray;
 }

--- a/Angular/src/app/dashboard/bibliography/bibliography.component.scss
+++ b/Angular/src/app/dashboard/bibliography/bibliography.component.scss
@@ -1,1 +1,23 @@
+@use "../../mixins" as *;
 @import url("../dashboard.component.scss");
+
+/* Create, revise, delete buttons */
+.bibliography-button {
+  margin-right: 0.5rem;
+  color: $theme-secondary;
+}
+
+#create-bibliography-button {
+  border-style: dashed;
+}
+
+#delete-bibliography-button:enabled {
+  @include button-dashed-background;
+  background: repeating-linear-gradient(-65deg, #fff2f2, #fff2f2 12px, #ffffff 5px, #ffffff 25px);
+}
+
+#delete-bibliography-button:disabled {
+  @include button-dashed-background;
+  background: repeating-linear-gradient(-65deg, #f8f8f8, #f8f8f8 12px, #ffffff 5px, #ffffff 25px);
+  color: darkgray;
+}

--- a/Angular/src/app/dashboard/bibliography/bibliography.component.spec.ts
+++ b/Angular/src/app/dashboard/bibliography/bibliography.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BibliographyComponent } from './bibliography.component';
+
+describe('BibliographyComponent', () => {
+  let component: BibliographyComponent;
+  let fixture: ComponentFixture<BibliographyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BibliographyComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BibliographyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Angular/src/app/dashboard/bibliography/bibliography.component.ts
+++ b/Angular/src/app/dashboard/bibliography/bibliography.component.ts
@@ -1,0 +1,212 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormArray, FormControl, FormGroup } from '@angular/forms';
+import { MatTabChangeEvent } from '@angular/material/tabs';
+import { ApiService } from '@oscc/api.service';
+import { AuthService } from '@oscc/auth/auth.service';
+import { DialogService } from '@oscc/services/dialog.service';
+import { Observable, map, startWith } from 'rxjs';
+
+@Component({
+  selector: 'app-bibliography',
+  templateUrl: './bibliography.component.html',
+  styleUrls: ['./bibliography.component.scss'],
+})
+export class BibliographyComponent implements OnInit {
+  // This component get fragment_form from dashboard so that it can extract linked_bib_entries from it.
+  @Input() fragment_form: FormGroup;
+
+  retrieved_bibliography_authors: object;
+  retrieved_author_bibliography: object;
+
+  bibliography_form = new FormGroup({
+    _id: new FormControl(''),
+    bib_entry_type: new FormControl('book'), // Book is default on page load
+    author: new FormControl(''),
+    title: new FormControl(''),
+    year: new FormControl(''),
+    series: new FormControl(''),
+    number: new FormControl(''),
+    location: new FormControl(''),
+    edition: new FormControl(''),
+    journal: new FormControl(''),
+    volume: new FormControl(''),
+    pages: new FormControl(''),
+  });
+
+  // Bibliography author selection
+  bibliography_author_selection_form = new FormControl();
+  bibliography_author_selection_form_options: string[] = [];
+  bibliography_author_selection_form_filtered_options: Observable<string[]>;
+  bibliography_form_selected_type = new FormControl(0);
+  bib_entry_selected = false;
+
+  constructor(protected auth_service: AuthService, protected api: ApiService, protected dialog: DialogService) {}
+
+  /**
+   * On Init, we just load the list of authors. From here, selection is started
+   */
+  ngOnInit(): void {
+    // this.RequestAuthors()
+    this.request_bibliography_authors();
+
+    this.bibliography_author_selection_form_filtered_options =
+      this.bibliography_author_selection_form.valueChanges.pipe(
+        startWith(''),
+        map((value) => this.filter_autocomplete_options(value))
+      );
+  }
+
+  /**
+   * Filters the list of authors based on the user's search input
+   * @param value user input
+   * @return bibliography authors that match the user's input
+   * @author Ycreak CptVickers
+   */
+  private filter_autocomplete_options(value: string): string[] {
+    const filterValue = value.toLowerCase();
+    return this.bibliography_author_selection_form_options.filter((option) =>
+      option.toLowerCase().includes(filterValue)
+    );
+  }
+
+  /**
+   * When changing the entry type for bibliographies, this function makes sure the type
+   * is communicated with the bibliography form.
+   * @author Ycreak, CptVickers
+   * @param tab_change_event angular event that gives the bibliography type to be changed to.
+   */
+  public on_bibliography_tab_change(tab_change_event: MatTabChangeEvent): void {
+    this.bibliography_form.patchValue({ bib_entry_type: tab_change_event.tab.textLabel.toLowerCase() });
+  }
+
+  /**
+   * When a bibliography entry is selected by the user, put all relevant data in the fields for easy
+   * revision.
+   * @param bib_entry with data for the selected entry
+   * @author Ycreak, CptVickers
+   */
+  public handle_bib_entry_selection(bib_entry) {
+    console.log(bib_entry.bib_entry_type);
+    // Jump automatically to the correct tab. FIXME: this works buggy
+    if (bib_entry.bib_entry_type == 'book') this.bibliography_form_selected_type.setValue(0);
+    if (bib_entry.bib_entry_type == 'article') this.bibliography_form_selected_type.setValue(1);
+
+    this.bibliography_form.patchValue({ _id: bib_entry._id });
+    this.bibliography_form.patchValue({ author: bib_entry.author });
+    this.bibliography_form.patchValue({ title: bib_entry.title });
+    this.bibliography_form.patchValue({ year: bib_entry.year });
+    this.bibliography_form.patchValue({ series: bib_entry.series });
+    this.bibliography_form.patchValue({ number: bib_entry.number });
+    this.bibliography_form.patchValue({ location: bib_entry.location });
+    this.bibliography_form.patchValue({ edition: bib_entry.edition });
+    this.bibliography_form.patchValue({ journal: bib_entry.journal });
+    this.bibliography_form.patchValue({ volume: bib_entry.volume });
+    this.bibliography_form.patchValue({ pages: bib_entry.pages });
+  }
+
+  /**
+   * Converts JSON into a angular list
+   * @param authors_json json object from the server
+   * @returns angular list with bibliography author names
+   * @authors Ycreak
+   */
+  public push_bibliography_authors_in_list(authors_json) {
+    const author_list: string[] = [];
+
+    for (const author in authors_json) {
+      author_list.push(authors_json[author].name);
+    }
+    return author_list;
+  }
+
+  /**
+   * Requests a list of authors from the bibliography database. Puts it in bibliography_author_selection_form_options for
+   * use in the autocomplete module
+   * @author Ycreak
+   */
+  public request_bibliography_authors() {
+    // this.api.get_bibliography_authors().subscribe({
+    //   next: (data) => {
+    //     this.bibliography_author_selection_form_options = this.push_bibliography_authors_in_list(data); //TODO: this need to be handled with a model
+    //   },
+    //   error: (err) => this.api.handle_error_message(err),
+    // });
+  }
+
+  public request_bibliography_from_author(author) {
+    // this.api.get_bibliography_from_author(author).subscribe((data) => {
+    //   this.retrieved_author_bibliography = data;
+    // });
+  }
+
+  /**
+   * This function request bibliography entries given its id. It then updates the fields
+   * corresponding to this id for the Fragment Bibliography tab to use. TODO: Find a way to share this with dashboard.
+   * @param id identifier of the bibliography document
+   * @author Ycreak, CptVickers
+   */
+  public request_bibliography_from_id(id) {
+    // this.api.get_bibliography_from_id(id).subscribe((data) => {
+    //   const temp = data; // simple object to access Python JSON (TODO: needs to be Angular model)
+    //   const linked_bib_entries = this.fragment_form.get('linked_bib_entries') as FormArray;
+    //   // Find the entry with our id
+    //   const index = linked_bib_entries.value.findIndex((x) => x.bib_id === id);
+    //   // Add the data retrieved to the corresponding fields
+    //   linked_bib_entries.at(index).get('author').setValue(temp.author);
+    //   linked_bib_entries.at(index).get('title').setValue(temp.title);
+    //   linked_bib_entries.at(index).get('year').setValue(temp.year);
+    // });
+  }
+
+  public request_revise_bibliography_entry(bibliography) {
+    // const item_string = bibliography.author + ', ' + bibliography.title;
+    // this.dialog
+    //   .open_confirmation_dialog('Are you sure you want to REVISE this bibliography entry?', item_string)
+    //   .subscribe((result) => {
+    //     if (result) {
+    //       this.api.revise_bibliography_entry(bibliography).subscribe({
+    //         next: (res) => {
+    //           this.api.handle_error_message(res), this.request_bibliography_authors(); // After a succesful response, retrieve the authors again.
+    //         },
+    //         error: (err) => this.api.handle_error_message(err),
+    //       });
+    //     }
+    //   });
+    // this.bibliography_form.reset();
+  }
+
+  public request_create_bibliography_entry(bibliography) {
+    // const item_string = bibliography.author + ', ' + bibliography.title;
+    // this.dialog
+    //   .open_confirmation_dialog('Are you sure you want to CREATE this bibliography entry?', item_string)
+    //   .subscribe((result) => {
+    //     if (result) {
+    //       this.api.create_bibliography_entry(bibliography).subscribe({
+    //         next: (res) => {
+    //           this.api.handle_error_message(res), this.request_bibliography_authors(); // After a succesful response, retrieve the authors again.
+    //         },
+    //         error: (err) => this.api.handle_error_message(err),
+    //       });
+    //     }
+    //   });
+    // this.bibliography_form.reset();
+  }
+
+  public request_delete_bibliography_entry(bibliography) {
+    // const item_string = bibliography.author + ', ' + bibliography.title;
+    // this.dialog
+    //   .open_confirmation_dialog('Are you sure you want to DELETE this bibliography entry?', item_string)
+    //   .subscribe((result) => {
+    //     if (result) {
+    //       this.api.delete_bibliography_entry({ _id: bibliography._id }).subscribe({
+    //         next: (res) => {
+    //           this.api.handle_error_message(res), this.request_bibliography_authors(); // After a succesful response, retrieve the authors again.
+    //         },
+    //         error: (err) => this.api.handle_error_message(err),
+    //       });
+    //     }
+    //   });
+    // this.bibliography_form.reset();
+    // this.bib_entry_selected = false;
+  }
+}

--- a/Angular/src/app/dashboard/dashboard.component.html
+++ b/Angular/src/app/dashboard/dashboard.component.html
@@ -573,6 +573,84 @@
         </mat-tab>
         <!-- end of the Fragment referencer tab -->
 
+        <mat-tab label="Fragment Bibliography"
+          ><br />
+
+          <div class="alert alert-info" role="alert">
+            The OSCC has a build-in bibliography management system which is accessible to all users. Simply search for
+            your author using the field below and press the appropriate title to add the source to your fragment. If
+            your entry does not exist yet, create it using the <b>Change bibliography data</b> panel. Do not forget to
+            press <b>Revise Fragment</b> to save changes.
+          </div>
+
+          <!-- Find the name of your author -->
+          <form class="example-form">
+            <mat-form-field class="example-full-width" appearance="fill">
+              <mat-label>Search an author</mat-label>
+              <input
+                type="text"
+                placeholder="Type author name"
+                aria-label="Author"
+                matInput
+                [formControl]="this.bibliography.bibliography_author_selection_form"
+                [matAutocomplete]="auto" />
+              <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
+                <mat-option
+                  *ngFor="let option of this.bibliography.bibliography_author_selection_form_filtered_options | async"
+                  [value]="option"
+                  (click)="this.bibliography.request_bibliography_from_author(option)">
+                  {{ option }}
+                </mat-option>
+              </mat-autocomplete>
+              <mat-hint>Found titles will be listed below</mat-hint>
+            </mat-form-field>
+          </form>
+
+          <mat-selection-list [multiple]="false">
+            <mat-list-option
+              *ngFor="let bib_entry of this.bibliography.retrieved_author_bibliography"
+              [value]="bib_entry"
+              (click)="this.push_bibliography_reference(bib_entry)"
+              (click)="this.bibliography.bib_entry_selected = true">
+              {{ bib_entry.author }}, {{ bib_entry.title }}, {{ bib_entry.year }}
+            </mat-list-option>
+            <!-- TODO: No such function 'push_bibliography_reference'?-->
+          </mat-selection-list>
+
+          <hr />
+
+          <div class="div-padding-lg"></div>
+
+          <div
+            formArrayName="linked_bib_entries"
+            *ngFor="let item of fragment_form.get('linked_bib_entries')['controls']; let i = index">
+            <div [formGroupName]="i">
+              <!-- <mat-form-field class="input-form-small">
+                <mat-label>Linked bibliography entry</mat-label>
+                <input matInput type="text" formControlName="bib_id" readonly>
+              </mat-form-field> -->
+
+              <mat-form-field class="input-form-small">
+                <mat-label>Author</mat-label>
+                <input matInput formControlName="author" readonly />
+              </mat-form-field>
+
+              <mat-form-field class="input-form-small">
+                <mat-label>Title</mat-label>
+                <input matInput type="text" formControlName="title" readonly />
+              </mat-form-field>
+
+              <mat-form-field class="input-form-small">
+                <mat-label>Year</mat-label>
+                <input matInput type="text" formControlName="year" readonly />
+              </mat-form-field>
+
+              <button mat-button (click)="Remove_form_item('linked_bib_entries', i)">Delete this source</button>
+            </div>
+          </div>
+        </mat-tab>
+        <!-- End of the fragment bibliography tab -->
+
         <mat-tab label="Fragment Access" *ngIf="this.auth_service.current_user_role === 'teacher'"
           ><br />
           <!-- This tab changes the fragment access. It has to parts. A lock function which disallows change and publish function
@@ -812,5 +890,9 @@
         </form>
       </div>
     </mat-expansion-panel>
+
+    <!-- Edit bibliography expansion panel -->
+    <app-bibliography [fragment_form]="fragment_form"></app-bibliography>
+    <hr />
   </mat-accordion>
 </div>

--- a/Angular/src/app/dashboard/dashboard.component.ts
+++ b/Angular/src/app/dashboard/dashboard.component.ts
@@ -22,6 +22,7 @@ import { Fragment } from '@oscc/models/Fragment';
 import { Column } from '@oscc/models/Column';
 import { User } from '@oscc/models/User';
 import { IntroductionsComponent } from './introductions/introductions.component';
+import { BibliographyComponent } from './bibliography/bibliography.component';
 
 @Component({
   selector: 'app-dashboard',
@@ -42,7 +43,7 @@ import { IntroductionsComponent } from './introductions/introductions.component'
       transition(':leave', [animate('500ms', style({ opacity: 0, transform: 'translateY(10px)' }))]),
     ]),
   ],
-  providers: [IntroductionsComponent],
+  providers: [IntroductionsComponent, BibliographyComponent],
 })
 export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
   // For the user table
@@ -106,6 +107,7 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
     status: new FormControl('', Validators.required),
     published: new FormControl(''),
     lock: new FormControl(''),
+    linked_bib_entries: new FormControl(''),
   });
 
   /**
@@ -138,10 +140,13 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
     protected utility: UtilityService,
     protected dialog: DialogService,
     protected auth_service: AuthService,
-    protected introductions: IntroductionsComponent
+    protected introductions: IntroductionsComponent,
+    protected bibliography: BibliographyComponent
   ) {
     // Assign the data to the data source for the table to render
     this.user_table_users = new MatTableDataSource(this.retrieved_users);
+
+    this.bibliography.bibliography_author_selection_form_filtered_options;
   }
 
   ngOnInit(): void {

--- a/Angular/src/app/dashboard/introductions/introductions.component.html
+++ b/Angular/src/app/dashboard/introductions/introductions.component.html
@@ -35,7 +35,7 @@
         *ngFor="let title of this.api.get_title_list(this.selected_introduction_data.author)"
         [value]="title"
         (click)="this.selected_introduction_data.title = title"
-        (click)="this.reset_introduction_form()"
+        (click)="this.reset_introduction_form('title_text')"
         (click)="this.introduction_form_group.patchValue({ author: author })"
         (click)="this.introduction_form_group.patchValue({ title: title })"
         (click)="this.api.request_introduction(this.selected_introduction_data)">

--- a/Angular/src/app/dashboard/introductions/introductions.component.ts
+++ b/Angular/src/app/dashboard/introductions/introductions.component.ts
@@ -39,9 +39,15 @@ export class IntroductionsComponent implements OnInit {
    * Function to reset the fragment form
    * @author CptVickers
    */
-  protected reset_introduction_form(): void {
-    // First, remove all data from the form
-    this.introduction_form_group.reset();
+  protected reset_introduction_form(field?: string): void {
+    if (field == 'author_text') {
+      this.introduction_form_group.patchValue({ author_text: '' });
+    } else if (field == 'title_text') {
+      this.introduction_form_group.patchValue({ title_text: '' });
+    } else {
+      // Remove all data from the form
+      this.introduction_form_group.reset();
+    }
     // Reset the saved changes hint
     this.show_changes_saved_hint = false;
   }

--- a/Angular/src/app/dashboard/introductions/introductions.component.ts
+++ b/Angular/src/app/dashboard/introductions/introductions.component.ts
@@ -4,7 +4,6 @@ import { ApiService } from '@oscc/api.service';
 import { AuthService } from '@oscc/auth/auth.service';
 import { Introduction_form } from '@oscc/models/Introduction_form';
 import { Introductions } from '@oscc/dashboard/introductions/Introduction_example';
-import { UtilityService } from '../../utility.service';
 import { DialogService } from '@oscc/services/dialog.service';
 
 @Component({
@@ -49,10 +48,10 @@ export class IntroductionsComponent implements OnInit {
 
   /**
    * Function to request the introduction text for a given author or author + title and show it in a dialog.
-   * @param intro Introduction object with form data; contains selected author and title data.
+   * @param _intro Introduction object with form data; contains selected author and title data.
    * @author CptVickers
    */
-  public show_introduction_dialog(intro: Introduction_form): void {
+  public show_introduction_dialog(/*intro: Introduction_form*/): void {
     // TODO: This function just shows some demo text for now; It does not fetch the correct texts from the server.
     const introdemo = new Introductions();
     this.dialog.open_custom_dialog(introdemo.dict['Ennius']);
@@ -66,7 +65,7 @@ export class IntroductionsComponent implements OnInit {
    * @param field from fragment_form which is to be send and updated
    * @author Ycreak
    */
-  protected request_wysiwyg_dialog(field: string, index = 0): void {
+  protected request_wysiwyg_dialog(field: string): void {
     if (field == 'author_text' || field == 'title_text') {
       const text = this.introduction_form_group.value[field];
       this.dialog.open_wysiwyg_dialog(text).subscribe((result) => {

--- a/Angular/src/app/playground/playground.component.html
+++ b/Angular/src/app/playground/playground.component.html
@@ -59,7 +59,7 @@
     <div class="playground-button-container col-3">
       <button
         mat-stroked-button
-        class="playground-button button-margin"
+        class="playground-button playground-delete-button button-margin"
         color="accent"
         (click)="this.delete_clicked_item_from_playground(this.playground, 'fragment')">
         Delete fragment
@@ -68,7 +68,7 @@
     <div class="playground-button-container col-3">
       <button
         mat-stroked-button
-        class="playground-button button-margin"
+        class="playground-button playground-delete-button button-margin"
         color="accent"
         (click)="this.delete_clicked_item_from_playground(this.playground, 'note')">
         Delete note
@@ -77,7 +77,7 @@
     <div class="playground-button-container col-3">
       <button
         mat-stroked-button
-        class="button-dashed-background playground-button button-margin"
+        class="button-dashed-background playground-button playground-delete-button button-margin"
         color="warn"
         (click)="this.playground.fragments = []; this.playground.note_array = []">
         Clear playground

--- a/Angular/src/app/playground/playground.component.scss
+++ b/Angular/src/app/playground/playground.component.scss
@@ -55,7 +55,7 @@
 }
 
 button.button-dashed-background {
-  @include button-dashed-background;
+  @include button-dashed-background-yellow;
 }
 
 .button-margin {

--- a/Angular/src/app/playground/playground.component.scss
+++ b/Angular/src/app/playground/playground.component.scss
@@ -1,4 +1,5 @@
 /* Playground related CSS */
+@use "../_mixins.scss" as *;
 
 .note {
   // width: auto;
@@ -54,11 +55,7 @@
 }
 
 button.button-dashed-background {
-  background-position: 10px 0, 10px 0, 0 0, 0 0;
-  background-repeat: repeat;
-  opacity: 0.8;
-  background: repeating-linear-gradient(-65deg, #fff7e0, #fff7e0 12px, #ffffff 5px, #ffffff 25px);
-  border-color: rgba(0, 0, 0, 0.12);
+  @include button-dashed-background;
 }
 
 .button-margin {

--- a/Angular/src/app/playground/playground.component.scss
+++ b/Angular/src/app/playground/playground.component.scss
@@ -77,6 +77,10 @@ button.button-dashed-background {
   background-color: #f5f5f5;
 }
 
+.playground-delete-button {
+  color: $theme-secondary;
+}
+
 .playground-mat-form-field {
   padding-left: 0px;
 }

--- a/Angular/src/styles.scss
+++ b/Angular/src/styles.scss
@@ -1,7 +1,8 @@
 /* You can add global styles to this file, and also import other style files */
 /* @import "./app/app.component.scss"; */
-/* @import "~@angular/material/prebuilt-themes/indigo-pink.css"; */
+/* @import "~@angular/material/prebuilt-themes/indigo-pink.css";
 /* @import "~bootstrap/dist/css/bootstrap.css"; */
+@import url("app/_mixins.scss");
 
 html,
 body {


### PR DESCRIPTION
Bibliography front-end re-implementation

TODO: define PR spec.

- [x] Bibliography dashboard menu looks good
- [x] Bibliography inserter in fragment content rich text editor <-- We'll make a separate issue for that


Also check:
- [x] #137 Warnings removed from introductions.component.ts
- [x] #130 Introduction text editor no longer wipes author introduction when different title introduction text is selected.


Closes #131, also closes #137 and closes #130

On top of that I found that the colors of the playground buttons weren't entirely consistent, so I changed those as well