### PR TITLE
Sajvanwijk/issue143 and Sajvanwijk/issue148

### DIFF
--- a/Angular/src/app/app.module.ts
+++ b/Angular/src/app/app.module.ts
@@ -88,6 +88,7 @@ import { PlaygroundComponent } from './playground/playground.component';
 import { CommentaryComponent } from './commentary/commentary.component';
 import { OverviewComponent } from './overview/overview.component';
 import { IntroductionsComponent } from './dashboard/introductions/introductions.component';
+import { ExpandableTextComponent } from './other_components/expandable-text/expandable-text.component';
 
 // Routes to take. Disallows Path Traversal.
 const appRoutes: Routes = [
@@ -118,6 +119,7 @@ const appRoutes: Routes = [
     OverviewComponent,
     IntroductionsComponent,
     BibliographyComponent,
+    ExpandableTextComponent,
   ],
   imports: [
     BrowserModule,

--- a/Angular/src/app/commentary/commentary.component.html
+++ b/Angular/src/app/commentary/commentary.component.html
@@ -128,7 +128,8 @@
       </mat-expansion-panel-header>
       <div class="mat-expansion-panel-content">
         <div class="mat-expansion-panel-body">
-          <div [innerHTML]="current_fragment_content"></div>
+          <app-expandable-text [content]="current_fragment_content"></app-expandable-text>
+          <!-- TODO: This is currently not applied to citation context -->
         </div>
       </div>
     </mat-expansion-panel>

--- a/Angular/src/app/other_components/expandable-text/expandable-text.component.html
+++ b/Angular/src/app/other_components/expandable-text/expandable-text.component.html
@@ -1,9 +1,13 @@
 <!-- This component adds the possibility to expand and collapse the view of the given content-->
 <div class="collapsed-text-container">
+  <!-- Main content div -->
   <div
     [innerHTML]="content"
-    [class.collapsed-text]="this.isCollapsed"
+    [class.collapsed-text]="this.isCollapsed && !this.maskDisabled"
+    [class.collapsed-text-no-gradient-mask]="this.maskDisabled"
     [class.uncollapsed-text]="!this.isCollapsed"></div>
+  <!-- Hideable content div -->
+  <div [hidden]="isCollapsed" [innerHTML]="content_hideable"></div>
   <button mat-button class="collapse-expand-button" *ngIf="this.enabled" (click)="this.ToggleCollapsed()">
     {{ this.GetToggleButtonText }}
   </button>

--- a/Angular/src/app/other_components/expandable-text/expandable-text.component.html
+++ b/Angular/src/app/other_components/expandable-text/expandable-text.component.html
@@ -1,0 +1,10 @@
+<!-- This component adds the possibility to expand and collapse the view of the given content-->
+<div class="collapsed-text-container">
+  <div
+    [innerHTML]="content"
+    [class.collapsed-text]="this.isCollapsed"
+    [class.uncollapsed-text]="!this.isCollapsed"></div>
+  <button mat-button class="collapse-expand-button" *ngIf="this.enabled" (click)="this.ToggleCollapsed()">
+    {{ this.GetToggleButtonText }}
+  </button>
+</div>

--- a/Angular/src/app/other_components/expandable-text/expandable-text.component.scss
+++ b/Angular/src/app/other_components/expandable-text/expandable-text.component.scss
@@ -2,11 +2,21 @@ div.collapsed-text-container {
   display: grid;
 }
 
-div.collapsed-text {
+%collapsed-text {
   max-height: var(--collapsed-height);
   overflow: hidden;
+}
+
+div.collapsed-text {
+  @extend %collapsed-text;
   mask-image: linear-gradient(180deg, black 60%, transparent);
   -webkit-mask-image: linear-gradient(180deg, black 60%, transparent);
+}
+
+div.collapsed-text-no-gradient-mask {
+  @extend %collapsed-text;
+  overflow: visible;
+  max-height: fit-content;
 }
 
 div.collapsed-text p {

--- a/Angular/src/app/other_components/expandable-text/expandable-text.component.scss
+++ b/Angular/src/app/other_components/expandable-text/expandable-text.component.scss
@@ -1,0 +1,28 @@
+div.collapsed-text-container {
+  display: grid;
+}
+
+div.collapsed-text {
+  max-height: var(--collapsed-height);
+  overflow: hidden;
+  mask-image: linear-gradient(180deg, black 60%, transparent);
+  -webkit-mask-image: linear-gradient(180deg, black 60%, transparent);
+}
+
+div.collapsed-text p {
+  width: auto;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+div.uncollapsed-text {
+  max-height: none;
+  overflow: visible;
+}
+
+button.collapse-expand-button {
+  border: lightgray;
+  border-style: solid;
+  border-width: thin;
+  border-radius: 0.5rem;
+}

--- a/Angular/src/app/other_components/expandable-text/expandable-text.component.spec.ts
+++ b/Angular/src/app/other_components/expandable-text/expandable-text.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExpandableTextComponent } from './expandable-text.component';
+
+describe('ExpandableTextComponent', () => {
+  let component: ExpandableTextComponent;
+  let fixture: ComponentFixture<ExpandableTextComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ExpandableTextComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ExpandableTextComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Angular/src/app/other_components/expandable-text/expandable-text.component.ts
+++ b/Angular/src/app/other_components/expandable-text/expandable-text.component.ts
@@ -7,11 +7,13 @@ import { Component, Input, ElementRef, AfterViewInit, ChangeDetectorRef } from '
   styleUrls: ['./expandable-text.component.scss'],
 })
 export class ExpandableTextComponent implements AfterViewInit {
-  @Input() content: any;
+  @Input() content: string; // HTML content
   @Input() isCollapsed?: boolean;
   @Input() collapsedHeightPx?: number; // Height when collapsed in em;
 
   protected enabled: boolean;
+  protected maskDisabled = false;
+  protected content_hideable: string;
 
   constructor(private elRef: ElementRef, private cdRef: ChangeDetectorRef) {
     this.enabled = true;
@@ -22,17 +24,32 @@ export class ExpandableTextComponent implements AfterViewInit {
   }
 
   ngAfterViewInit() {
-    /** Check if the content is so small that it does not need to be collapsed */
-    // Get current content height
-    const contentHeight = this.elRef.nativeElement.offsetHeight;
+    // Check if the content has a hidden section
+    // If so, hide this section, hide the gradient mask and set the component height to fit-content.
+    if (this.content.includes('[hidden]')) {
+      // Hide the to-be-hidden text to the hideable section
+      this.content = this.content.replace('[/hidden]', ''); // Remove leftover tags
+      [this.content, this.content_hideable] = this.content.split('[hidden]');
 
-    if (contentHeight < this.collapsedHeightPx) {
-      // There is not enough content to warrant an expand content button. Let's hide it from view.
-      this.enabled = false;
-      // Also make sure the element isn't collapsed.
-      this.isCollapsed = false;
+      // Remove the gradient mask
+      // This also sets the component height to fit-content
+      this.maskDisabled = true;
+
       // Push the changes to the Angular change detector
       this.cdRef.detectChanges();
+    } else {
+      /** Check if the content is so small that it does not need to be collapsed */
+      // Get current content height
+      const contentHeight = this.elRef.nativeElement.offsetHeight;
+
+      if (contentHeight < this.collapsedHeightPx) {
+        // There is not enough content to warrant an expand content button. Let's hide it from view.
+        this.enabled = false;
+        // Also make sure the element isn't collapsed.
+        this.isCollapsed = false;
+        // Push the changes to the Angular change detector
+        this.cdRef.detectChanges();
+      }
     }
   }
 
@@ -41,7 +58,17 @@ export class ExpandableTextComponent implements AfterViewInit {
    * @author CptVickers
    */
   protected ToggleCollapsed() {
+    // If the content contains a hidden section, unhide TODO:
+    if (this.isCollapsed) {
+      this.content = this.content.replace('<span hidden>', "<span name='unhidden'>");
+    } else {
+      this.content = this.content.replace("<span name='unhidden'>", '<span hidden>');
+    }
+
     this.isCollapsed = !this.isCollapsed;
+
+    // Push the changes to the Angular change detector
+    this.cdRef.detectChanges();
   }
 
   /**

--- a/Angular/src/app/other_components/expandable-text/expandable-text.component.ts
+++ b/Angular/src/app/other_components/expandable-text/expandable-text.component.ts
@@ -29,7 +29,9 @@ export class ExpandableTextComponent implements AfterViewInit {
     if (this.content.includes('[hidden]')) {
       // Hide the to-be-hidden text to the hideable section
       this.content = this.content.replace('[/hidden]', ''); // Remove leftover tags
-      [this.content, this.content_hideable] = this.content.split('[hidden]');
+      let content_hideable_arr: Array<string>;
+      [this.content, ...content_hideable_arr] = this.content.split('[hidden]');
+      this.content_hideable = content_hideable_arr.join();
 
       // Remove the gradient mask
       // This also sets the component height to fit-content

--- a/Angular/src/app/other_components/expandable-text/expandable-text.component.ts
+++ b/Angular/src/app/other_components/expandable-text/expandable-text.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ElementRef, AfterViewInit } from '@angular/core';
+import { Component, Input, ElementRef, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 //import { CommentaryComponent } from '../../commentary/commentary.component';
 
 @Component({
@@ -13,7 +13,7 @@ export class ExpandableTextComponent implements AfterViewInit {
 
   protected enabled: boolean;
 
-  constructor(private elRef: ElementRef) {
+  constructor(private elRef: ElementRef, private cdRef: ChangeDetectorRef) {
     this.enabled = true;
     this.isCollapsed = this.isCollapsed || true; // Set isCollapsed to true by default
     this.collapsedHeightPx = 200; // Element height is 200px by default when collapsed FIXME: Em would be nicer, but would also make the comparison in the ngAfterViewInit below a bit more difficult.
@@ -31,6 +31,8 @@ export class ExpandableTextComponent implements AfterViewInit {
       this.enabled = false;
       // Also make sure the element isn't collapsed.
       this.isCollapsed = false;
+      // Push the changes to the Angular change detector
+      this.cdRef.detectChanges();
     }
   }
 

--- a/Angular/src/app/other_components/expandable-text/expandable-text.component.ts
+++ b/Angular/src/app/other_components/expandable-text/expandable-text.component.ts
@@ -18,7 +18,7 @@ export class ExpandableTextComponent implements AfterViewInit {
   constructor(private elRef: ElementRef, private cdRef: ChangeDetectorRef) {
     this.enabled = true;
     this.isCollapsed = this.isCollapsed || true; // Set isCollapsed to true by default
-    this.collapsedHeightPx = 200; // Element height is 200px by default when collapsed FIXME: Em would be nicer, but would also make the comparison in the ngAfterViewInit below a bit more difficult.
+    this.collapsedHeightPx = this.collapsedHeightPx || 200; // Element height is 200px by default when collapsed FIXME: Em would be nicer, but would also make the comparison in the ngAfterViewInit below a bit more difficult.
     // Send this variable to the css
     document.querySelector('body').style.setProperty('--collapsed-height', String(this.collapsedHeightPx + 'px'));
   }
@@ -29,7 +29,7 @@ export class ExpandableTextComponent implements AfterViewInit {
     if (this.content.includes('[hidden]')) {
       // Hide the to-be-hidden text to the hideable section
       this.content = this.content.replace('[/hidden]', ''); // Remove leftover tags
-      let content_hideable_arr: Array<string>;
+      let content_hideable_arr: string[];
       [this.content, ...content_hideable_arr] = this.content.split('[hidden]');
       this.content_hideable = content_hideable_arr.join();
 
@@ -59,7 +59,7 @@ export class ExpandableTextComponent implements AfterViewInit {
    * Function used by the toggle button to change between collapsed and expanded view.
    * @author CptVickers
    */
-  protected ToggleCollapsed() {
+  protected toggle_collapsed() {
     // If the content contains a hidden section, unhide TODO:
     if (this.isCollapsed) {
       this.content = this.content.replace('<span hidden>', "<span name='unhidden'>");
@@ -77,7 +77,7 @@ export class ExpandableTextComponent implements AfterViewInit {
    * Function used by the toggle button to get a relevant label based on the element being expanded or collapsed
    * @author CptVickers
    */
-  protected get GetToggleButtonText() {
+  protected get get_toggle_button_text() {
     if (this.isCollapsed === true) {
       return 'Show more';
     } else {

--- a/Angular/src/app/other_components/expandable-text/expandable-text.component.ts
+++ b/Angular/src/app/other_components/expandable-text/expandable-text.component.ts
@@ -1,0 +1,56 @@
+import { Component, Input, ElementRef, AfterViewInit } from '@angular/core';
+//import { CommentaryComponent } from '../../commentary/commentary.component';
+
+@Component({
+  selector: 'app-expandable-text',
+  templateUrl: './expandable-text.component.html',
+  styleUrls: ['./expandable-text.component.scss'],
+})
+export class ExpandableTextComponent implements AfterViewInit {
+  @Input() content: any;
+  @Input() isCollapsed?: boolean;
+  @Input() collapsedHeightPx?: number; // Height when collapsed in em;
+
+  protected enabled: boolean;
+
+  constructor(private elRef: ElementRef) {
+    this.enabled = true;
+    this.isCollapsed = this.isCollapsed || true; // Set isCollapsed to true by default
+    this.collapsedHeightPx = 200; // Element height is 200px by default when collapsed FIXME: Em would be nicer, but would also make the comparison in the ngAfterViewInit below a bit more difficult.
+    // Send this variable to the css
+    document.querySelector('body').style.setProperty('--collapsed-height', String(this.collapsedHeightPx + 'px'));
+  }
+
+  ngAfterViewInit() {
+    /** Check if the content is so small that it does not need to be collapsed */
+    // Get current content height
+    const contentHeight = this.elRef.nativeElement.offsetHeight;
+
+    if (contentHeight < this.collapsedHeightPx) {
+      // There is not enough content to warrant an expand content button. Let's hide it from view.
+      this.enabled = false;
+      // Also make sure the element isn't collapsed.
+      this.isCollapsed = false;
+    }
+  }
+
+  /**
+   * Function used by the toggle button to change between collapsed and expanded view.
+   * @author CptVickers
+   */
+  protected ToggleCollapsed() {
+    this.isCollapsed = !this.isCollapsed;
+  }
+
+  /**
+   * Function used by the toggle button to get a relevant label based on the element being expanded or collapsed
+   * @author CptVickers
+   */
+  protected get GetToggleButtonText() {
+    if (this.isCollapsed === true) {
+      return 'Show more';
+    } else {
+      return 'Show less';
+    }
+  }
+}


### PR DESCRIPTION
closes #143, closes #148
These issues are quite closely-knit, so i put them together into a single PR

#143:
This adds a way that text in the commentary can be partially collapsed to make the ui less cluttered
This introduces a new component that acts as a wrapper for the content that is to be made collapsible
If the text in this component is beyond a certain length, it will automatically be collapsed with a 'show more' button to expand it. If the text is below this length, the button will not appear.

#148:
On top of this, I added a way to collapse text to a certain point. This can be done by adding the [hidden] tag to a text. The text beyond that tag will be automatically collapsed.

TODO: 
#143:
- [ ] Add a button for this to the wysiwyg editor
- [ ]  Add a tooltip to this button, as it's purpose might be a bit unclear otherwise

Functional tests:
#143:
- [x] Open Ennius Thyestes TRF 132
- [x] Open the fragment translation tab in the commentary. Note that it is unchanged
- [x] Open the fragment commentary tab. Note that the text is collapsed
- [x] Click the 'show more' button to expand
- [x] Click the 'Show less' button to collapse again
- [x] The new feature should look nice

#148:
- [x] Click on the Apparatus Criticus tab in the commentary
- [x] Note that the explanation bit is hidden
- [x] Test the collapse and uncollapse button as before.
- [x] Note that if the user inputs a [/summary] end tag, it will be automatically removed as it is redundant.
- [x] Note that if multiple [summary] tags are supplied, it will only take the first one into regard.

