### PR TITLE
Confirmation prompt for the clear playground button

### DIFF
--- a/Angular/src/app/playground/playground.component.html
+++ b/Angular/src/app/playground/playground.component.html
@@ -79,7 +79,7 @@
         mat-stroked-button
         class="button-dashed-background playground-button playground-delete-button button-margin"
         color="warn"
-        (click)="this.playground.fragments = []; this.playground.note_array = []">
+        (click)="this.clear_playground()">
         Clear playground
       </button>
     </div>

--- a/Angular/src/app/playground/playground.component.ts
+++ b/Angular/src/app/playground/playground.component.ts
@@ -143,7 +143,7 @@ export class PlaygroundComponent implements OnInit, OnDestroy, AfterViewInit {
   protected clear_playground(): void {
     this.dialog.open_confirmation_dialog('Are you sure you want to clear the playground?', '').subscribe({
       next: (res) => {
-        if (res === true) {
+        if (res) {
           this.playground.fragments = [];
           this.playground.note_array = [];
         }

--- a/Angular/src/app/playground/playground.component.ts
+++ b/Angular/src/app/playground/playground.component.ts
@@ -11,6 +11,7 @@ import { SettingsService } from '@oscc/services/settings.service';
 // Model imports
 import { Fragment } from '@oscc/models/Fragment';
 import { Column } from '@oscc/models/Column';
+import { DialogService } from '@oscc/services/dialog.service';
 
 @Component({
   selector: 'app-playground',
@@ -37,7 +38,8 @@ export class PlaygroundComponent implements OnInit, OnDestroy, AfterViewInit {
     protected api: ApiService,
     protected utility: UtilityService,
     protected settings: SettingsService,
-    protected column_handler: ColumnHandlerService
+    protected column_handler: ColumnHandlerService,
+    protected dialog: DialogService
   ) {}
 
   ngOnInit(): void {
@@ -133,5 +135,21 @@ export class PlaygroundComponent implements OnInit, OnDestroy, AfterViewInit {
     this.single_fragment_requested = true;
     // format the fragment and push it to the list
     this.api.request_fragments(column.column_id, column.author, column.title, column.editor, fragment_name);
+  }
+
+  /**
+   * @author CptVickers
+   */
+  protected clear_playground(): void {
+    this.dialog
+      .open_confirmation_dialog('Are you sure you want to clear the playground?', this.playground.fragments)
+      .subscribe({
+        next: (res) => {
+          if (res === true) {
+            this.playground.fragments = [];
+            this.playground.note_array = [];
+          }
+        },
+      });
   }
 }

--- a/Angular/src/app/playground/playground.component.ts
+++ b/Angular/src/app/playground/playground.component.ts
@@ -141,15 +141,13 @@ export class PlaygroundComponent implements OnInit, OnDestroy, AfterViewInit {
    * @author CptVickers
    */
   protected clear_playground(): void {
-    this.dialog
-      .open_confirmation_dialog('Are you sure you want to clear the playground?', this.playground.fragments)
-      .subscribe({
-        next: (res) => {
-          if (res === true) {
-            this.playground.fragments = [];
-            this.playground.note_array = [];
-          }
-        },
-      });
+    this.dialog.open_confirmation_dialog('Are you sure you want to clear the playground?', '').subscribe({
+      next: (res) => {
+        if (res === true) {
+          this.playground.fragments = [];
+          this.playground.note_array = [];
+        }
+      },
+    });
   }
 }


### PR DESCRIPTION
Fixes #146

Functional tests:
Add a fragment and a note to the playground
- [x] Click the clear playground button. Clicking no in the confirmation prompt should preserve the playground
- [x] Click the clear playground button. Clicking yes in the confirmation prompt should clear the playground
- [x] The confirmation prompt should look good