### PR TITLE
Toggle to show translations in the columns

### DIFF
--- a/Angular/src/app/commentary/commentary.component.html
+++ b/Angular/src/app/commentary/commentary.component.html
@@ -44,17 +44,7 @@
 
 <!-- Template for commentary column -->
 <ng-template #commentary_column_template let-given_fragment="given_fragment">
-  <ng-container *ngIf="!this.fragments_translated">
-    <ng-container
-      *ngTemplateOutlet="
-        show_fragment_content_frag_translation;
-        context: { current_fragment_content: given_fragment.translation, title: 'Fragment Translation' }
-      ">
-    </ng-container>
-  </ng-container>
-  <!-- Show the translation of the fragment -->
-
-  <ng-container *ngIf="this.fragments_translated">
+  <ng-container *ngIf="this.current_fragment.fragments_translated; else fragments_not_translated">
     <ng-container
       *ngTemplateOutlet="
         show_fragment_content_orig_text;
@@ -62,6 +52,16 @@
       ">
     </ng-container>
   </ng-container>
+  <!-- Show the translation of the fragment -->
+
+  <ng-template #fragments_not_translated>
+    <ng-container
+      *ngTemplateOutlet="
+        show_fragment_content;
+        context: { current_fragment_content: given_fragment.translation, title: 'Fragment Translation' }
+      ">
+    </ng-container>
+  </ng-template>
   <!-- Show the fragment's original text -->
 
   <ng-container
@@ -174,33 +174,6 @@
               <p [innerHTML]="fragment_line.text | safeHtml"></p>
             </ng-template>
           </div>
-        </div>
-      </div>
-    </mat-expansion-panel>
-    <hr />
-    <!-- And add a nice line to separate the fields -->
-  </ng-container>
-</ng-template>
-
-<!-- Template to show fragment content from the given fragment in a mat expansion panel -->
-<ng-template
-  #show_fragment_content_frag_translation
-  let-current_fragment_content="current_fragment_content"
-  let-title="title">
-  <ng-container *ngIf="current_fragment_content !== ''">
-    <!-- do not generate fields if content is empty -->
-    <mat-expansion-panel
-      *ngIf="current_fragment_content"
-      [expanded]="this.translation_orig_text_expanded"
-      (click)="toggle_translation_orig_text_expanded()">
-      <mat-expansion-panel-header>
-        <mat-panel-title>
-          <b>{{ title }}</b>
-        </mat-panel-title>
-      </mat-expansion-panel-header>
-      <div class="mat-expansion-panel-content">
-        <div class="mat-expansion-panel-body">
-          <div [innerHTML]="current_fragment_content"></div>
         </div>
       </div>
     </mat-expansion-panel>

--- a/Angular/src/app/commentary/commentary.component.html
+++ b/Angular/src/app/commentary/commentary.component.html
@@ -44,13 +44,25 @@
 
 <!-- Template for commentary column -->
 <ng-template #commentary_column_template let-given_fragment="given_fragment">
-  <ng-container
-    *ngTemplateOutlet="
-      show_fragment_content;
-      context: { current_fragment_content: given_fragment.translation, title: 'Fragment Translation' }
-    ">
+  <ng-container *ngIf="!this.fragments_translated">
+    <ng-container
+      *ngTemplateOutlet="
+        show_fragment_content;
+        context: { current_fragment_content: given_fragment.translation, title: 'Fragment Translation' }
+      ">
+    </ng-container>
   </ng-container>
   <!-- Show the translation of the fragment -->
+
+  <ng-container *ngIf="this.fragments_translated">
+    <ng-container
+      *ngTemplateOutlet="
+        show_fragment_content_lines;
+        context: { current_fragment_content: given_fragment.lines, title: 'Original text' }
+      ">
+    </ng-container>
+  </ng-container>
+  <!-- Show the fragment's original text -->
 
   <ng-container
     *ngTemplateOutlet="
@@ -129,6 +141,36 @@
       <div class="mat-expansion-panel-content">
         <div class="mat-expansion-panel-body">
           <div [innerHTML]="current_fragment_content"></div>
+        </div>
+      </div>
+    </mat-expansion-panel>
+    <hr />
+    <!-- And add a nice line to separate the fields -->
+  </ng-container>
+</ng-template>
+
+<!-- TODO: Maybe we should make a public template for displaying the fragment lines -->
+<!-- Template to show fragment content from the given fragment in a mat expansion panel -->
+<ng-template #show_fragment_content_lines let-current_fragment_content="current_fragment_content" let-title="title">
+  <ng-container *ngIf="current_fragment_content !== ''">
+    <!-- do not generate fields if content is empty -->
+    <mat-expansion-panel *ngIf="current_fragment_content">
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          <b>{{ title }}</b>
+        </mat-panel-title>
+      </mat-expansion-panel-header>
+      <div class="mat-expansion-panel-content">
+        <div class="mat-expansion-panel-body">
+          <div *ngFor="let fragment_line of current_fragment_content">
+            <p
+              *ngIf="this.settings.fragments.show_line_names; else no_line_names"
+              [innerHTML]="fragment_line.line_number + ': ' + fragment_line.text | safeHtml"></p>
+            <ng-template #no_line_names>
+              <!--safeHtml to allow whitespaces made by spans-->
+              <p [innerHTML]="fragment_line.text | safeHtml"></p>
+            </ng-template>
+          </div>
         </div>
       </div>
     </mat-expansion-panel>

--- a/Angular/src/app/commentary/commentary.component.html
+++ b/Angular/src/app/commentary/commentary.component.html
@@ -152,7 +152,7 @@
 
 <!-- Template to show fragment content from the given fragment in a mat expansion panel -->
 <ng-template #show_fragment_content_orig_text let-current_fragment_content="current_fragment_content" let-title="title">
-  <ng-container *ngIf="current_fragment_content !== ''">
+  <ng-container *ngIf="current_fragment_content.length > 0">
     <!-- do not generate fields if content is empty -->
     <mat-expansion-panel
       *ngIf="current_fragment_content"

--- a/Angular/src/app/commentary/commentary.component.html
+++ b/Angular/src/app/commentary/commentary.component.html
@@ -47,7 +47,7 @@
   <ng-container *ngIf="!this.fragments_translated">
     <ng-container
       *ngTemplateOutlet="
-        show_fragment_content;
+        show_fragment_content_frag_translation;
         context: { current_fragment_content: given_fragment.translation, title: 'Fragment Translation' }
       ">
     </ng-container>
@@ -57,7 +57,7 @@
   <ng-container *ngIf="this.fragments_translated">
     <ng-container
       *ngTemplateOutlet="
-        show_fragment_content_lines;
+        show_fragment_content_orig_text;
         context: { current_fragment_content: given_fragment.lines, title: 'Original text' }
       ">
     </ng-container>
@@ -128,6 +128,7 @@
   <!-- Show the fragment metrical analysis -->
 </ng-template>
 
+<!-- ###### TEMPLATES ###### -->
 <!-- Template to show fragment content from the given fragment in a mat expansion panel -->
 <ng-template #show_fragment_content let-current_fragment_content="current_fragment_content" let-title="title">
   <ng-container *ngIf="current_fragment_content !== ''">
@@ -149,12 +150,14 @@
   </ng-container>
 </ng-template>
 
-<!-- TODO: Maybe we should make a public template for displaying the fragment lines -->
 <!-- Template to show fragment content from the given fragment in a mat expansion panel -->
-<ng-template #show_fragment_content_lines let-current_fragment_content="current_fragment_content" let-title="title">
+<ng-template #show_fragment_content_orig_text let-current_fragment_content="current_fragment_content" let-title="title">
   <ng-container *ngIf="current_fragment_content !== ''">
     <!-- do not generate fields if content is empty -->
-    <mat-expansion-panel *ngIf="current_fragment_content">
+    <mat-expansion-panel
+      *ngIf="current_fragment_content"
+      [expanded]="this.translation_orig_text_expanded"
+      (click)="toggle_translation_orig_text_expanded()">
       <mat-expansion-panel-header>
         <mat-panel-title>
           <b>{{ title }}</b>
@@ -171,6 +174,33 @@
               <p [innerHTML]="fragment_line.text | safeHtml"></p>
             </ng-template>
           </div>
+        </div>
+      </div>
+    </mat-expansion-panel>
+    <hr />
+    <!-- And add a nice line to separate the fields -->
+  </ng-container>
+</ng-template>
+
+<!-- Template to show fragment content from the given fragment in a mat expansion panel -->
+<ng-template
+  #show_fragment_content_frag_translation
+  let-current_fragment_content="current_fragment_content"
+  let-title="title">
+  <ng-container *ngIf="current_fragment_content !== ''">
+    <!-- do not generate fields if content is empty -->
+    <mat-expansion-panel
+      *ngIf="current_fragment_content"
+      [expanded]="this.translation_orig_text_expanded"
+      (click)="toggle_translation_orig_text_expanded()">
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          <b>{{ title }}</b>
+        </mat-panel-title>
+      </mat-expansion-panel-header>
+      <div class="mat-expansion-panel-content">
+        <div class="mat-expansion-panel-body">
+          <div [innerHTML]="current_fragment_content"></div>
         </div>
       </div>
     </mat-expansion-panel>

--- a/Angular/src/app/commentary/commentary.component.ts
+++ b/Angular/src/app/commentary/commentary.component.ts
@@ -1,10 +1,12 @@
 import { Component, Input, OnInit, SimpleChanges, OnChanges } from '@angular/core';
 import { ApiService } from '@oscc/api.service';
 import { IntroductionsComponent } from '@oscc/dashboard/introductions/introductions.component';
+import { FragmentsComponent } from '@oscc/fragments/fragments.component';
 
 // Model imports
 import { Fragment } from '@oscc/models/Fragment';
 import { DialogService } from '@oscc/services/dialog.service';
+import { SettingsService } from '@oscc/services/settings.service';
 
 // Service imports
 import { UtilityService } from '@oscc/utility.service';
@@ -13,18 +15,21 @@ import { UtilityService } from '@oscc/utility.service';
   selector: 'app-commentary',
   templateUrl: './commentary.component.html',
   styleUrls: ['./commentary.component.scss'],
-  providers: [IntroductionsComponent],
+  providers: [IntroductionsComponent, FragmentsComponent],
 })
 export class CommentaryComponent implements OnInit, OnChanges {
   @Input() current_fragment: Fragment;
 
   protected fragment_clicked = false;
+  protected fragments_translated = this.fragments.fragments_translated || false;
 
   constructor(
     protected utility: UtilityService,
     protected api: ApiService,
     protected dialog: DialogService,
-    private introductions: IntroductionsComponent
+    protected settings: SettingsService,
+    private introductions: IntroductionsComponent,
+    private fragments: FragmentsComponent
   ) {}
 
   ngOnInit(): void {
@@ -38,5 +43,9 @@ export class CommentaryComponent implements OnInit, OnChanges {
       this.fragment_clicked = true;
       this.current_fragment.convert_bib_entries(this.api.zotero);
     }
+  }
+
+  public set set_fragments_translated(bool: boolean) {
+    this.fragments_translated = bool; //TODO: move to ngOnChanges?
   }
 }

--- a/Angular/src/app/commentary/commentary.component.ts
+++ b/Angular/src/app/commentary/commentary.component.ts
@@ -19,9 +19,9 @@ import { UtilityService } from '@oscc/utility.service';
 })
 export class CommentaryComponent implements OnInit, OnChanges {
   @Input() current_fragment: Fragment;
+  @Input() fragments_translated: boolean;
 
   protected fragment_clicked = false;
-  protected fragments_translated = this.fragments.fragments_translated || false;
 
   constructor(
     protected utility: UtilityService,
@@ -39,13 +39,11 @@ export class CommentaryComponent implements OnInit, OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     // If the input fragment changes, we will note that a fragment has been clicked
-    if (changes.current_fragment.currentValue.author != '') {
-      this.fragment_clicked = true;
-      this.current_fragment.convert_bib_entries(this.api.zotero);
+    if (changes.current_fragment) {
+      if (changes.current_fragment.currentValue.author != '') {
+        this.fragment_clicked = true;
+        this.current_fragment.convert_bib_entries(this.api.zotero);
+      }
     }
-  }
-
-  public set set_fragments_translated(bool: boolean) {
-    this.fragments_translated = bool; //TODO: move to ngOnChanges?
   }
 }

--- a/Angular/src/app/commentary/commentary.component.ts
+++ b/Angular/src/app/commentary/commentary.component.ts
@@ -22,6 +22,7 @@ export class CommentaryComponent implements OnInit, OnChanges {
   @Input() fragments_translated: boolean;
 
   protected fragment_clicked = false;
+  protected translation_orig_text_expanded = false;
 
   constructor(
     protected utility: UtilityService,
@@ -45,5 +46,15 @@ export class CommentaryComponent implements OnInit, OnChanges {
         this.current_fragment.convert_bib_entries(this.api.zotero);
       }
     }
+  }
+
+  /**
+   * Function to toggle the expansion state of the fragment translation/original text sections
+   * The expansion state is stored as a variable in this component so that it persists between
+   * DOM changes.
+   * @author CptVickers
+   */
+  protected toggle_translation_orig_text_expanded(): void {
+    this.translation_orig_text_expanded = !this.translation_orig_text_expanded;
   }
 }

--- a/Angular/src/app/fragments/fragments.component.html
+++ b/Angular/src/app/fragments/fragments.component.html
@@ -7,15 +7,14 @@
   <mat-toolbar class="fragment-column-toolbar">
     <!-- Button to select the text -->
     <button
-      style="color: white"
+      class="fragment-column-button"
       mat-button
       [matMenuTriggerFor]="menu_authors"
       (click)="column_to_display.new_column = false">
       Select text
     </button>
     <button
-      style="color: white"
-      ;
+      class="fragment-column-button"
       mat-button
       (click)="this.toggle_translation()"
       [innerHTML]="this.translation_toggle_button_label"></button>

--- a/Angular/src/app/fragments/fragments.component.html
+++ b/Angular/src/app/fragments/fragments.component.html
@@ -14,10 +14,11 @@
       Select text
     </button>
     <button
+      *ngIf="column_to_display.has_translations()"
       class="fragment-column-button"
       mat-button
-      (click)="this.toggle_translation()"
-      [innerHTML]="this.translation_toggle_button_label"></button>
+      (click)="this.toggle_translation(column_to_display)"
+      [innerHTML]="this.translation_toggle_button_label(column_to_display)"></button>
 
     <!-- Nested menu to select author - title - editor. -->
     <mat-menu #menu_authors="matMenu">
@@ -137,7 +138,7 @@
     <div *ngFor="let fragment of given_column.fragments">
       <div
         class="fragment-box"
-        (click)="handle_fragment_click(fragment)"
+        (click)="handle_fragment_click(fragment, given_column)"
         cdkDrag
         [cdkDragDisabled]="this.settings.fragments.dragging_disabled"
         (cdkDragDropped)="this.column_handler.track_edited_columns($event)"
@@ -153,7 +154,12 @@
           <sup>{{ fragment.author }}, {{ fragment.title }}, {{ fragment.editor }}</sup> &nbsp;
           <i>{{ fragment.status }}</i>
         </div>
-        <ng-container *ngIf="!this.fragments_translated; else translated_text_template">
+        <ng-container *ngIf="given_column.fragments_translated; else fragments_not_translated">
+          <div>
+            <p [innerHTML]="fragment.translation"></p>
+          </div>
+        </ng-container>
+        <ng-template #fragments_not_translated>
           <div *ngFor="let fragment_line of fragment.lines">
             <p
               *ngIf="this.settings.fragments.show_line_names; else no_line_names"
@@ -162,11 +168,6 @@
               <!--safeHtml to allow whitespaces made by spans-->
               <p [innerHTML]="fragment_line.text | safeHtml"></p>
             </ng-template>
-          </div>
-        </ng-container>
-        <ng-template #translated_text_template>
-          <div>
-            <p [innerHTML]="fragment.translation"></p>
           </div>
         </ng-template>
       </div>

--- a/Angular/src/app/fragments/fragments.component.html
+++ b/Angular/src/app/fragments/fragments.component.html
@@ -13,6 +13,12 @@
       (click)="column_to_display.new_column = false">
       Select text
     </button>
+    <button
+      style="color: white"
+      ;
+      mat-button
+      (click)="this.toggle_translation()"
+      [innerHTML]="this.translation_toggle_button_label"></button>
 
     <!-- Nested menu to select author - title - editor. -->
     <mat-menu #menu_authors="matMenu">
@@ -148,15 +154,22 @@
           <sup>{{ fragment.author }}, {{ fragment.title }}, {{ fragment.editor }}</sup> &nbsp;
           <i>{{ fragment.status }}</i>
         </div>
-        <div *ngFor="let fragment_line of fragment.lines">
-          <p
-            *ngIf="this.settings.fragments.show_line_names; else no_line_names"
-            [innerHTML]="fragment_line.line_number + ': ' + fragment_line.text | safeHtml"></p>
-          <ng-template #no_line_names>
-            <!--safeHtml to allow whitespaces made by spans-->
-            <p [innerHTML]="fragment_line.text | safeHtml"></p>
-          </ng-template>
-        </div>
+        <ng-container *ngIf="!this.fragments_translated; else translated_text_template">
+          <div *ngFor="let fragment_line of fragment.lines">
+            <p
+              *ngIf="this.settings.fragments.show_line_names; else no_line_names"
+              [innerHTML]="fragment_line.line_number + ': ' + fragment_line.text | safeHtml"></p>
+            <ng-template #no_line_names>
+              <!--safeHtml to allow whitespaces made by spans-->
+              <p [innerHTML]="fragment_line.text | safeHtml"></p>
+            </ng-template>
+          </div>
+        </ng-container>
+        <ng-template #translated_text_template>
+          <div>
+            <p [innerHTML]="fragment.translation"></p>
+          </div>
+        </ng-template>
       </div>
       <!--</div>-->
     </div>

--- a/Angular/src/app/fragments/fragments.component.scss
+++ b/Angular/src/app/fragments/fragments.component.scss
@@ -31,8 +31,6 @@ ng-template {
   color: black;
 }
 
-/* Fragment and commentary column related CSS */
-
 /* Box in which the fragment is shown. Created by the for-loop in Fragment Column. */
 .fragment-box {
   padding: 10px 5px 0px 5px;
@@ -120,4 +118,8 @@ ng-template {
   color: white;
   /* outline: 1px solid black; */
   background: #9fa1fe;
+}
+
+.fragment-column-button {
+  color: white;
 }

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -33,9 +33,12 @@ import { Column } from '@oscc/models/Column';
 })
 export class FragmentsComponent implements OnInit, OnDestroy {
   @Output() fragment_clicked2 = new EventEmitter<Fragment>();
+  @Output() fragments_translated_event = new EventEmitter<boolean>();
 
   public current_fragment: Fragment; // Variable to store the clicked fragment and its data
   fragment_clicked = false; // Shows "click a fragment" banner at startup if nothing is yet selected
+
+  public fragments_translated: boolean; // Variable to indicate whether or not the translated text should be displayed.
 
   // Subscription variables
   private fragments_subscription: any;
@@ -196,6 +199,31 @@ export class FragmentsComponent implements OnInit, OnDestroy {
       return `HSL(0, 0%, ${calculated_brightness}%)`;
     } else {
       return 'transparent';
+    }
+  }
+
+  /**
+   * This function allows the user to display the translations of the fragments instead of the original text.
+   * The Fragment Translation tab in the commentary section then becomes the 'original text' tab instead.
+   * @author CptVickers
+   */
+  protected toggle_translation(): void {
+    // Toggle the text in the fragments column
+    this.fragments_translated = !this.fragments_translated;
+
+    // Emit an event so that the commentary section can process the change
+    this.fragments_translated_event.emit(this.fragments_translated);
+  }
+
+  /**
+   * Function to get an appropriate label for the toggle translation button
+   * @author CptVickers
+   */
+  protected get translation_toggle_button_label(): string {
+    if (this.fragments_translated === true) {
+      return 'Show original text';
+    } else {
+      return 'Show translation';
     }
   }
 }

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -219,7 +219,7 @@ export class FragmentsComponent implements OnInit, OnDestroy {
    * @author CptVickers
    */
   protected get translation_toggle_button_label(): string {
-    if (this.fragments_translated === true) {
+    if (this.fragments_translated) {
       return 'Show original text';
     } else {
       return 'Show translation';

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -1,6 +1,6 @@
 // Library imports
 import { Component, OnInit, OnDestroy, ViewEncapsulation } from '@angular/core';
-import { Output, EventEmitter } from '@angular/core';
+import { Input, Output, EventEmitter } from '@angular/core';
 import { trigger, transition, style, animate } from '@angular/animations';
 //import { environment } from '@src/environments/environment';
 
@@ -32,13 +32,12 @@ import { Column } from '@oscc/models/Column';
   ],
 })
 export class FragmentsComponent implements OnInit, OnDestroy {
+  @Input() fragments_translated: boolean;
   @Output() fragment_clicked2 = new EventEmitter<Fragment>();
   @Output() fragments_translated_event = new EventEmitter<boolean>();
 
   public current_fragment: Fragment; // Variable to store the clicked fragment and its data
   fragment_clicked = false; // Shows "click a fragment" banner at startup if nothing is yet selected
-
-  public fragments_translated: boolean; // Variable to indicate whether or not the translated text should be displayed.
 
   // Subscription variables
   private fragments_subscription: any;
@@ -211,7 +210,7 @@ export class FragmentsComponent implements OnInit, OnDestroy {
     // Toggle the text in the fragments column
     this.fragments_translated = !this.fragments_translated;
 
-    // Emit an event so that the commentary section can process the change
+    // Emit an event so that the other components can process the change
     this.fragments_translated_event.emit(this.fragments_translated);
   }
 

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -1,6 +1,6 @@
 // Library imports
 import { Component, OnInit, OnDestroy, ViewEncapsulation } from '@angular/core';
-import { Input, Output, EventEmitter } from '@angular/core';
+import { Output, EventEmitter } from '@angular/core';
 import { trigger, transition, style, animate } from '@angular/animations';
 //import { environment } from '@src/environments/environment';
 
@@ -32,9 +32,7 @@ import { Column } from '@oscc/models/Column';
   ],
 })
 export class FragmentsComponent implements OnInit, OnDestroy {
-  @Input() fragments_translated: boolean;
-  @Output() fragment_clicked2 = new EventEmitter<Fragment>();
-  @Output() fragments_translated_event = new EventEmitter<boolean>();
+  @Output() new_commentary = new EventEmitter<Fragment>();
 
   public current_fragment: Fragment; // Variable to store the clicked fragment and its data
   fragment_clicked = false; // Shows "click a fragment" banner at startup if nothing is yet selected
@@ -104,11 +102,15 @@ export class FragmentsComponent implements OnInit, OnDestroy {
   /**
    * Function to handle what happens when a fragment is selected in HTML.
    * @param fragment selected by the user
+   * @param Column
    * @author Ycreak
    */
-  protected handle_fragment_click(fragment: Fragment): void {
-    this.fragment_clicked2.emit(fragment);
-    // If we are currently dragging a fragment in the playground, we do not want the click even to fire.
+  protected handle_fragment_click(fragment: Fragment, column: Column): void {
+    //TODO: we need to emit a commentary object to the commentary
+    fragment.fragments_translated = column.fragments_translated;
+    this.new_commentary.emit(fragment);
+
+    //this.fragment_clicked2.emit(fragment);
     this.fragment_clicked = true;
     this.current_fragment = fragment;
 
@@ -206,20 +208,16 @@ export class FragmentsComponent implements OnInit, OnDestroy {
    * The Fragment Translation tab in the commentary section then becomes the 'original text' tab instead.
    * @author CptVickers
    */
-  protected toggle_translation(): void {
-    // Toggle the text in the fragments column
-    this.fragments_translated = !this.fragments_translated;
-
-    // Emit an event so that the other components can process the change
-    this.fragments_translated_event.emit(this.fragments_translated);
+  protected toggle_translation(column: Column): void {
+    column.fragments_translated = !column.fragments_translated;
   }
 
   /**
    * Function to get an appropriate label for the toggle translation button
    * @author CptVickers
    */
-  protected get translation_toggle_button_label(): string {
-    if (this.fragments_translated) {
+  protected translation_toggle_button_label(column: Column): string {
+    if (column.fragments_translated) {
       return 'Show original text';
     } else {
       return 'Show translation';

--- a/Angular/src/app/models/Column.ts
+++ b/Angular/src/app/models/Column.ts
@@ -50,4 +50,17 @@ export class Column {
 
   // Original order of the column fragments
   original_fragment_order: string[] = [];
+
+  // If fragments translated, shows translation in column and original text in the commentary
+  fragments_translated = false;
+
+  // Checks if the column is able to show fragment translations
+  has_translations(): boolean {
+    for (const i in this.fragments) {
+      if (this.fragments[i].translation) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/Angular/src/app/models/Fragment.ts
+++ b/Angular/src/app/models/Fragment.ts
@@ -19,6 +19,9 @@ export class Fragment {
   metrical_analysis: string;
   context: Context[];
 
+  // TODO: this needs to be part of the commentary object
+  fragments_translated = false;
+
   status = '';
   lines: Line[] = [];
   linked_fragments: Linked_fragment[] = [];

--- a/Angular/src/app/overview/overview.component.html
+++ b/Angular/src/app/overview/overview.component.html
@@ -79,8 +79,9 @@
   <mat-drawer-container class="drawer-container" autosize>
     <div class="overview-sidenav-content">
       <app-fragments
-        (fragment_clicked2)="this.current_fragment = $event"
-        (fragments_translated_event)="toggle_fragments_translated($event)">
+        [fragments_translated]="this.fragments_translated"
+        (fragments_translated_event)="this.fragments_translated = $event"
+        (fragment_clicked2)="this.current_fragment = $event">
       </app-fragments>
     </div>
 
@@ -94,7 +95,11 @@
       position="end"
       opened="true">
       <div style="padding: 0.5em">
-        <app-commentary #commentary [current_fragment]="this.current_fragment"> </app-commentary>
+        <app-commentary
+          #commentary
+          [current_fragment]="this.current_fragment"
+          [fragments_translated]="this.fragments_translated">
+        </app-commentary>
       </div>
     </mat-drawer>
   </mat-drawer-container>

--- a/Angular/src/app/overview/overview.component.html
+++ b/Angular/src/app/overview/overview.component.html
@@ -78,7 +78,10 @@
 <div>
   <mat-drawer-container class="drawer-container" autosize>
     <div class="overview-sidenav-content">
-      <app-fragments (fragment_clicked2)="this.current_fragment = $event"> </app-fragments>
+      <app-fragments
+        (fragment_clicked2)="this.current_fragment = $event"
+        (fragments_translated_event)="toggle_fragments_translated($event)">
+      </app-fragments>
     </div>
 
     <hr />
@@ -91,7 +94,7 @@
       position="end"
       opened="true">
       <div style="padding: 0.5em">
-        <app-commentary [current_fragment]="this.current_fragment"> </app-commentary>
+        <app-commentary #commentary [current_fragment]="this.current_fragment"> </app-commentary>
       </div>
     </mat-drawer>
   </mat-drawer-container>

--- a/Angular/src/app/overview/overview.component.html
+++ b/Angular/src/app/overview/overview.component.html
@@ -78,11 +78,7 @@
 <div>
   <mat-drawer-container class="drawer-container" autosize>
     <div class="overview-sidenav-content">
-      <app-fragments
-        [fragments_translated]="this.fragments_translated"
-        (fragments_translated_event)="this.fragments_translated = $event"
-        (fragment_clicked2)="this.current_fragment = $event">
-      </app-fragments>
+      <app-fragments (new_commentary)="this.current_fragment = $event"> </app-fragments>
     </div>
 
     <hr />
@@ -95,11 +91,7 @@
       position="end"
       opened="true">
       <div style="padding: 0.5em">
-        <app-commentary
-          #commentary
-          [current_fragment]="this.current_fragment"
-          [fragments_translated]="this.fragments_translated">
-        </app-commentary>
+        <app-commentary #commentary [current_fragment]="this.current_fragment"> </app-commentary>
       </div>
     </mat-drawer>
   </mat-drawer-container>

--- a/Angular/src/app/overview/overview.component.ts
+++ b/Angular/src/app/overview/overview.component.ts
@@ -35,6 +35,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
   protected commentary_enabled = true;
   protected commentary_is_reduced_size = false;
   protected playground_enabled = true;
+  protected fragments_translated = false; // Indicates if fragments in frag.col. should be shown translated
 
   protected current_fragment: Fragment;
 
@@ -101,15 +102,6 @@ export class OverviewComponent implements OnInit, OnDestroy {
    */
   protected toggle_playground(): void {
     this.playground_enabled = !this.playground_enabled;
-  }
-
-  /**
-   * This function communicates a change in fragments_translated status
-   * to other elements.
-   * @author CptVickers
-   */
-  protected toggle_fragments_translated(bool: boolean): void {
-    this.commentary.set_fragments_translated = bool;
   }
 
   /**

--- a/Angular/src/app/overview/overview.component.ts
+++ b/Angular/src/app/overview/overview.component.ts
@@ -1,6 +1,6 @@
 // Library imports
 
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog'; // Library used for interacting with the page
 import { environment } from '@src/environments/environment';
 
@@ -21,6 +21,7 @@ import { LoginComponent } from '@oscc/login/login.component';
 import { Fragment } from '@oscc/models/Fragment';
 import { ColumnHandlerService } from '@oscc/services/column-handler.service';
 import { LocalStorageService } from '@oscc/services/local-storage.service';
+import { CommentaryComponent } from '@oscc/commentary/commentary.component';
 
 @Component({
   selector: 'app-overview',
@@ -29,6 +30,8 @@ import { LocalStorageService } from '@oscc/services/local-storage.service';
   providers: [FragmentsComponent],
 })
 export class OverviewComponent implements OnInit, OnDestroy {
+  @ViewChild('commentary') commentary: CommentaryComponent;
+
   protected commentary_enabled = true;
   protected commentary_is_reduced_size = false;
   protected playground_enabled = true;
@@ -98,6 +101,15 @@ export class OverviewComponent implements OnInit, OnDestroy {
    */
   protected toggle_playground(): void {
     this.playground_enabled = !this.playground_enabled;
+  }
+
+  /**
+   * This function communicates a change in fragments_translated status
+   * to other elements.
+   * @author CptVickers
+   */
+  protected toggle_fragments_translated(bool: boolean): void {
+    this.commentary.set_fragments_translated = bool;
   }
 
   /**

--- a/Angular/src/app/overview/overview.component.ts
+++ b/Angular/src/app/overview/overview.component.ts
@@ -33,9 +33,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
   @ViewChild('commentary') commentary: CommentaryComponent;
 
   protected commentary_enabled = true;
-  protected commentary_is_reduced_size = false;
   protected playground_enabled = true;
-  protected fragments_translated = false; // Indicates if fragments in frag.col. should be shown translated
 
   protected current_fragment: Fragment;
 
@@ -86,14 +84,6 @@ export class OverviewComponent implements OnInit, OnDestroy {
    */
   protected toggle_commentary(): void {
     this.commentary_enabled = !this.commentary_enabled;
-  }
-
-  /**
-   * Simple function to toggle the commentary column size
-   * @author CptVickers
-   */
-  protected toggle_commentary_size(): void {
-    this.commentary_is_reduced_size = !this.commentary_is_reduced_size;
   }
 
   /**


### PR DESCRIPTION
closes #147 

This feature adds a button to the fragment columns that allows you to switch between translation and original text. The commentary section will also switch between fragment translation and original text.

Todo: 
- [x] I was hoping that this would work on a per-column basis, but unfortunately it doesn't. So we have to decide to either fix that or to be okay with it and move the button somewhere else.


Functional tests: 
- [x] Click on a fragment. Then click the 'Show translation button.
- [x] The text changes correctly in the fragments section
- [x] The 'fragment translation' section in the commentary changes to the 'Original text' section which now holds the original text.
- [x] If you open the 'fragment translation' tab and then click the 'show translation' button, the 'original text' section that appears should already be open.