### PR TITLE
Added filter component and filter icon

### DIFF
--- a/Angular/src/app/api.service.ts
+++ b/Angular/src/app/api.service.ts
@@ -301,6 +301,23 @@ export class ApiService {
     });
   }
 
+  public request_documents(column_id: number, filter: object): void {
+    this.spinner_on();
+    this.fragments = [];
+    this.get_fragments(filter).subscribe({
+      next: (data) => {
+        data.forEach((value) => {
+          const fragment = new Fragment();
+          fragment.set_fragment(value);
+          this.fragments.push(fragment);
+        });
+        this.new_fragments_alert.next(column_id);
+        this.spinner_off();
+      },
+      error: (err) => this.handle_error_message(err),
+    });
+  }
+
   /**
    * Function to request the introduction text for a given author or author + title.
    * @param intro Introduction object with form data; contains selected author and title data.

--- a/Angular/src/app/api.service.ts
+++ b/Angular/src/app/api.service.ts
@@ -301,6 +301,12 @@ export class ApiService {
     });
   }
 
+  /**
+   * Requests documents from the server given a filter object
+   * @param number of column_id
+   * @param object of filter to apply to documents
+   * @author Ycreak
+   */
   public request_documents(column_id: number, filter: object): void {
     this.spinner_on();
     this.fragments = [];

--- a/Angular/src/app/app.module.ts
+++ b/Angular/src/app/app.module.ts
@@ -89,6 +89,7 @@ import { CommentaryComponent } from './commentary/commentary.component';
 import { OverviewComponent } from './overview/overview.component';
 import { IntroductionsComponent } from './dashboard/introductions/introductions.component';
 import { ExpandableTextComponent } from './other_components/expandable-text/expandable-text.component';
+import { DocumentFilterComponent } from './dialogs/document-filter/document-filter.component';
 
 // Routes to take. Disallows Path Traversal.
 const appRoutes: Routes = [
@@ -120,6 +121,7 @@ const appRoutes: Routes = [
     IntroductionsComponent,
     BibliographyComponent,
     ExpandableTextComponent,
+    DocumentFilterComponent,
   ],
   imports: [
     BrowserModule,

--- a/Angular/src/app/dialogs/document-filter/document-filter.component.html
+++ b/Angular/src/app/dialogs/document-filter/document-filter.component.html
@@ -17,6 +17,6 @@
       <mat-label> Status </mat-label>
       <input matInput formControlName="status" /> </mat-form-field
     ><br />
-    <button mat-stroked-button (click)="this.close_dialog()">Search</button>
+    <button mat-stroked-button (click)="this.submit_filter()">Search</button>
   </form>
 </div>

--- a/Angular/src/app/dialogs/document-filter/document-filter.component.html
+++ b/Angular/src/app/dialogs/document-filter/document-filter.component.html
@@ -1,0 +1,1 @@
+<p>document-filter works!</p>

--- a/Angular/src/app/dialogs/document-filter/document-filter.component.html
+++ b/Angular/src/app/dialogs/document-filter/document-filter.component.html
@@ -1,1 +1,22 @@
-<p>document-filter works!</p>
+<div style="padding: 2em">
+  <h5>Set custom filters</h5>
+  <form [formGroup]="this.form">
+    <mat-form-field appearance="outline">
+      <mat-label> Author </mat-label>
+      <input matInput formControlName="author" /> </mat-form-field
+    ><br />
+    <mat-form-field appearance="outline">
+      <mat-label> Title </mat-label>
+      <input matInput formControlName="title" /> </mat-form-field
+    ><br />
+    <mat-form-field appearance="outline">
+      <mat-label> Editor </mat-label>
+      <input matInput formControlName="editor" /> </mat-form-field
+    ><br />
+    <mat-form-field appearance="outline">
+      <mat-label> Status </mat-label>
+      <input matInput formControlName="status" /> </mat-form-field
+    ><br />
+    <button mat-stroked-button (click)="this.close_dialog()">Search</button>
+  </form>
+</div>

--- a/Angular/src/app/dialogs/document-filter/document-filter.component.spec.ts
+++ b/Angular/src/app/dialogs/document-filter/document-filter.component.spec.ts
@@ -8,9 +8,8 @@ describe('DocumentFilterComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ DocumentFilterComponent ]
-    })
-    .compileComponents();
+      declarations: [DocumentFilterComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(DocumentFilterComponent);
     component = fixture.componentInstance;

--- a/Angular/src/app/dialogs/document-filter/document-filter.component.spec.ts
+++ b/Angular/src/app/dialogs/document-filter/document-filter.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DocumentFilterComponent } from './document-filter.component';
+
+describe('DocumentFilterComponent', () => {
+  let component: DocumentFilterComponent;
+  let fixture: ComponentFixture<DocumentFilterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DocumentFilterComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DocumentFilterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Angular/src/app/dialogs/document-filter/document-filter.component.ts
+++ b/Angular/src/app/dialogs/document-filter/document-filter.component.ts
@@ -1,10 +1,44 @@
 import { Component } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-document-filter',
   templateUrl: './document-filter.component.html',
-  styleUrls: ['./document-filter.component.scss']
+  styleUrls: ['./document-filter.component.scss'],
 })
 export class DocumentFilterComponent {
+  form: any = new FormGroup({
+    author: new FormControl(''),
+    title: new FormControl(''),
+    editor: new FormControl(''),
+    status: new FormControl(''),
+  });
 
+  constructor(public dialogRef: MatDialogRef<DocumentFilterComponent>) {}
+
+  public test() {
+    console.log(this.form.value);
+  }
+
+  protected close_dialog() {
+    const return_form = this.remove_empty_form_fields(this.form.value);
+    this.dialogRef.close(return_form);
+  }
+
+  /**
+   * Removes all form values that are empty from the given object
+   * @param object that needs to be pruned
+   * @returns object that is pruned
+   * @author Ycreak
+   */
+  public remove_empty_form_fields(form_values: object): object {
+    const form = structuredClone(form_values);
+    for (const field in form) {
+      if (form[field] == '') {
+        delete form[field];
+      }
+    }
+    return form;
+  }
 }

--- a/Angular/src/app/dialogs/document-filter/document-filter.component.ts
+++ b/Angular/src/app/dialogs/document-filter/document-filter.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-document-filter',
+  templateUrl: './document-filter.component.html',
+  styleUrls: ['./document-filter.component.scss']
+})
+export class DocumentFilterComponent {
+
+}

--- a/Angular/src/app/dialogs/document-filter/document-filter.component.ts
+++ b/Angular/src/app/dialogs/document-filter/document-filter.component.ts
@@ -21,7 +21,7 @@ export class DocumentFilterComponent {
     console.log(this.form.value);
   }
 
-  protected close_dialog() {
+  protected submit_filter() {
     const return_form = this.remove_empty_form_fields(this.form.value);
     this.dialogRef.close(return_form);
   }

--- a/Angular/src/app/fragments/fragments.component.html
+++ b/Angular/src/app/fragments/fragments.component.html
@@ -19,7 +19,7 @@
       mat-button
       (click)="this.toggle_translation(column_to_display)"
       [innerHTML]="this.translation_toggle_button_label(column_to_display)"></button>
-
+    
     <!-- Nested menu to select author - title - editor. -->
     <mat-menu #menu_authors="matMenu">
       <ng-container *ngFor="let author of this.api.get_author_list(); let i = index">
@@ -69,6 +69,10 @@
     </mat-menu>
 
     <!-- Buttons to close columns or to move columns to left and right -->
+    <button mat-icon-button (click)="this.set_custom_filter()">
+      <mat-icon>filter_alt</mat-icon>
+    </button>
+
     <button mat-icon-button (click)="this.column_handler.move_column(column_to_display.column_id, 'left')">
       <mat-icon>keyboard_arrow_left</mat-icon>
     </button>

--- a/Angular/src/app/fragments/fragments.component.html
+++ b/Angular/src/app/fragments/fragments.component.html
@@ -19,7 +19,7 @@
       mat-button
       (click)="this.toggle_translation(column_to_display)"
       [innerHTML]="this.translation_toggle_button_label(column_to_display)"></button>
-    
+
     <!-- Nested menu to select author - title - editor. -->
     <mat-menu #menu_authors="matMenu">
       <ng-container *ngFor="let author of this.api.get_author_list(); let i = index">
@@ -55,6 +55,7 @@
           mat-menu-item
           (click)="column_to_display.editor = editor"
           (click)="column_to_display.edited = false"
+          (click)="column_to_display.fragments_translated = false"
           (click)="
             this.api.request_fragments(
               column_to_display.column_id,
@@ -69,7 +70,7 @@
     </mat-menu>
 
     <!-- Buttons to close columns or to move columns to left and right -->
-    <button mat-icon-button (click)="this.set_custom_filter()">
+    <button mat-icon-button (click)="this.set_custom_filter(column_to_display.column_id)">
       <mat-icon>filter_alt</mat-icon>
     </button>
 

--- a/Angular/src/app/fragments/fragments.component.html
+++ b/Angular/src/app/fragments/fragments.component.html
@@ -69,7 +69,7 @@
       </ng-container>
     </mat-menu>
 
-    <!-- Buttons to close columns or to move columns to left and right -->
+    <!-- Buttons to modify columns -->
     <button mat-icon-button (click)="this.set_custom_filter(column_to_display.column_id)">
       <mat-icon>filter_alt</mat-icon>
     </button>

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -2,6 +2,7 @@
 import { Component, OnInit, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { Output, EventEmitter } from '@angular/core';
 import { trigger, transition, style, animate } from '@angular/animations';
+import { MatDialog } from '@angular/material/dialog'; 
 //import { environment } from '@src/environments/environment';
 
 // Service imports
@@ -11,6 +12,7 @@ import { SettingsService } from '@oscc/services/settings.service';
 import { UtilityService } from '@oscc/utility.service';
 import { AuthService } from '@oscc/auth/auth.service';
 import { ColumnHandlerService } from '@oscc/services/column-handler.service';
+import { DocumentFilterComponent } from '@oscc/dialogs/document-filter/document-filter.component';
 
 // Model imports
 import { Fragment } from '@oscc/models/Fragment';
@@ -46,8 +48,8 @@ export class FragmentsComponent implements OnInit, OnDestroy {
     protected auth_service: AuthService,
     protected dialog: DialogService,
     protected settings: SettingsService,
-    //private matdialog: MatDialog,
-    protected column_handler: ColumnHandlerService
+    private matdialog: MatDialog,
+    protected column_handler: ColumnHandlerService,
   ) {}
 
   ngOnInit(): void {
@@ -222,5 +224,9 @@ export class FragmentsComponent implements OnInit, OnDestroy {
     } else {
       return 'Show translation';
     }
+  }
+  
+  protected set_custom_filter(): void {
+    this.matdialog.open(DocumentFilterComponent, {});
   }
 }

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -236,7 +236,6 @@ export class FragmentsComponent implements OnInit, OnDestroy {
     dialogRef.afterClosed().subscribe({
       next: (document_filter) => {
         if (document_filter) {
-          console.log(document_filter, 'data');
           this.api.request_documents(column_id, document_filter);
         }
       },

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -2,7 +2,7 @@
 import { Component, OnInit, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { Output, EventEmitter } from '@angular/core';
 import { trigger, transition, style, animate } from '@angular/animations';
-import { MatDialog } from '@angular/material/dialog'; 
+import { MatDialog } from '@angular/material/dialog';
 //import { environment } from '@src/environments/environment';
 
 // Service imports
@@ -49,7 +49,7 @@ export class FragmentsComponent implements OnInit, OnDestroy {
     protected dialog: DialogService,
     protected settings: SettingsService,
     private matdialog: MatDialog,
-    protected column_handler: ColumnHandlerService,
+    protected column_handler: ColumnHandlerService
   ) {}
 
   ngOnInit(): void {
@@ -225,8 +225,16 @@ export class FragmentsComponent implements OnInit, OnDestroy {
       return 'Show translation';
     }
   }
-  
-  protected set_custom_filter(): void {
-    this.matdialog.open(DocumentFilterComponent, {});
+
+  protected set_custom_filter(column_id: number): void {
+    const dialogRef = this.matdialog.open(DocumentFilterComponent, {});
+    dialogRef.afterClosed().subscribe({
+      next: (document_filter) => {
+        if (document_filter) {
+          console.log(document_filter, 'data');
+          this.api.request_documents(column_id, document_filter);
+        }
+      },
+    });
   }
 }

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -226,6 +226,11 @@ export class FragmentsComponent implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * Opens a dialog to set a custom filter. If filter set, requests documents from server
+   * @param number of column_id to load documents into
+   * @author Ycreak
+   */
   protected set_custom_filter(column_id: number): void {
     const dialogRef = this.matdialog.open(DocumentFilterComponent, {});
     dialogRef.afterClosed().subscribe({

--- a/Angular/src/app/other_components/expandable-text/expandable-text.component.html
+++ b/Angular/src/app/other_components/expandable-text/expandable-text.component.html
@@ -9,6 +9,6 @@
   <!-- Hideable content div -->
   <div [hidden]="isCollapsed" [innerHTML]="content_hideable"></div>
   <button mat-button class="collapse-expand-button" *ngIf="this.enabled" (click)="this.toggle_collapsed()">
-    {{ this.get_toggle_button_text}}
+    {{ this.get_toggle_button_text }}
   </button>
 </div>


### PR DESCRIPTION
This PR creates a custom filter for users to have more control over which documents to select. For now it is a simple proof of concept: will have to be extended in Flask first.

**Functional tests**
- [x] Select the filter button. Use _Ennius_ as author and _TRF_ as editor. Press _Search_. See that both _Eumenides_ and _Thyestes_ fragments are retrieved.
- [x] Select the filter button. Use _Aegisthus_ as title and _Ribbeck_ as editor. See that texts from _Livius Andronicus_ and _Accius_ are retrieved.
- [x] Select the filter button. Use something weird as author. See that a 401 snackbar is returned and the previous fragments remain on screen.
- [x] Select the filter button, type something somewhere and click outside the dialog. See that nothing happens.
