### PR TITLE
Commentary now in its own object

### DIFF
--- a/Angular/src/app/api.service.ts
+++ b/Angular/src/app/api.service.ts
@@ -211,8 +211,7 @@ export class ApiService {
   }
 
   public request_zotero_data() {
-    const url = 'https://api.zotero.org/groups/5089557/items?v=3';
-    this.get(url).subscribe({
+    this.get(environment.zotero_url).subscribe({
       next: (data) => {
         const bib_list: Bib[] = [];
         for (const i in data) {

--- a/Angular/src/app/commentary/commentary.component.html
+++ b/Angular/src/app/commentary/commentary.component.html
@@ -1,34 +1,8 @@
-<!-- <div *ngIf="commentary_enabled" class="col overflow_column"> TODO: -->
-<!-- Show either fragment data or the fact that no fragment has been selected yet. -->
-<div *ngIf="this.fragment_clicked; else no_fragment_clicked">
-  <!-- Fragment information -->
-  <h5>
-    Selected
-    <a class="a-void" (click)="this.introductions.show_introduction_dialog(this.current_fragment.author)">{{
-      this.current_fragment.author
-    }}</a
-    >,
-    <a class="a-void" (click)="this.introductions.show_introduction_dialog(this.current_fragment.title)">{{
-      this.current_fragment.title
-    }}</a
-    >, {{ this.current_fragment.editor }},
-    {{ this.current_fragment.name }}
-  </h5>
-</div>
-<ng-template #no_fragment_clicked>
-  <h5>Click a fragment to show its content.</h5>
-</ng-template>
-
-<!-- Show banner if no commentary available -->
-<div *ngIf="!this.current_fragment.has_content() && this.fragment_clicked" class="alert alert-info" role="alert">
-  No content is available yet for this specific fragment.
-</div>
-
 <!-- Show the commentary for the clicked fragment -->
-<div *ngIf="this.current_fragment.has_content()">
+<div>
   <ng-container
     [ngTemplateOutlet]="commentary_column_template"
-    [ngTemplateOutletContext]="{ given_fragment: this.current_fragment }"></ng-container>
+    [ngTemplateOutletContext]="{ given_fragment: this.commentary }"></ng-container>
 </div>
 
 <!-- TODO: <div *ngFor="let linked_fragment of this.commentary_column.linked_fragments_content">
@@ -44,7 +18,7 @@
 
 <!-- Template for commentary column -->
 <ng-template #commentary_column_template let-given_fragment="given_fragment">
-  <ng-container *ngIf="this.current_fragment.fragments_translated; else fragments_not_translated">
+  <ng-container *ngIf="this.fragments_translated; else fragments_not_translated">
     <ng-container
       *ngTemplateOutlet="
         show_fragment_content_orig_text;

--- a/Angular/src/app/commentary/commentary.component.ts
+++ b/Angular/src/app/commentary/commentary.component.ts
@@ -4,7 +4,7 @@ import { IntroductionsComponent } from '@oscc/dashboard/introductions/introducti
 import { FragmentsComponent } from '@oscc/fragments/fragments.component';
 
 // Model imports
-import { Fragment } from '@oscc/models/Fragment';
+import { Commentary } from '@oscc/models/Commentary';
 import { DialogService } from '@oscc/services/dialog.service';
 import { SettingsService } from '@oscc/services/settings.service';
 
@@ -17,8 +17,8 @@ import { UtilityService } from '@oscc/utility.service';
   styleUrls: ['./commentary.component.scss'],
   providers: [IntroductionsComponent, FragmentsComponent],
 })
-export class CommentaryComponent implements OnInit, OnChanges {
-  @Input() current_fragment: Fragment;
+export class CommentaryComponent implements OnChanges {
+  @Input() commentary: Commentary;
   @Input() fragments_translated: boolean;
 
   protected fragment_clicked = false;
@@ -29,22 +29,12 @@ export class CommentaryComponent implements OnInit, OnChanges {
     protected api: ApiService,
     protected dialog: DialogService,
     protected settings: SettingsService,
-    private introductions: IntroductionsComponent,
-    private fragments: FragmentsComponent
   ) {}
 
-  ngOnInit(): void {
-    this.api.request_zotero_data();
-    this.current_fragment = new Fragment({});
-  }
-
   ngOnChanges(changes: SimpleChanges) {
-    // If the input fragment changes, we will note that a fragment has been clicked
-    if (changes.current_fragment) {
-      if (changes.current_fragment.currentValue.author != '') {
-        this.fragment_clicked = true;
-        this.current_fragment.convert_bib_entries(this.api.zotero);
-      }
+    if (changes.commentary) {
+      this.commentary.add_html();
+      this.commentary.convert_bib_entries(this.api.zotero);
     }
   }
 

--- a/Angular/src/app/commentary/commentary.component.ts
+++ b/Angular/src/app/commentary/commentary.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, SimpleChanges, OnChanges } from '@angular/core';
+import { Component, Input, SimpleChanges, OnChanges } from '@angular/core';
 import { ApiService } from '@oscc/api.service';
 import { IntroductionsComponent } from '@oscc/dashboard/introductions/introductions.component';
 import { FragmentsComponent } from '@oscc/fragments/fragments.component';
@@ -28,7 +28,7 @@ export class CommentaryComponent implements OnChanges {
     protected utility: UtilityService,
     protected api: ApiService,
     protected dialog: DialogService,
-    protected settings: SettingsService,
+    protected settings: SettingsService
   ) {}
 
   ngOnChanges(changes: SimpleChanges) {

--- a/Angular/src/app/commentary/commentary.component.ts
+++ b/Angular/src/app/commentary/commentary.component.ts
@@ -33,6 +33,7 @@ export class CommentaryComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.commentary) {
+      console.log('comm', this.commentary);
       this.commentary.add_html();
       this.commentary.convert_bib_entries(this.api.zotero);
     }

--- a/Angular/src/app/dashboard/dashboard.component.html
+++ b/Angular/src/app/dashboard/dashboard.component.html
@@ -280,10 +280,6 @@
             have appeared. Do not add HTML for a paragraph here!
           </div>
 
-          <div class="alert alert-info" role="alert">
-            You can press <b>SHIFT</b> for the popup keyboard to reveal more metre and HTML possibilities.
-          </div>
-
           <form [formGroup]="fragment_form">
             <button mat-stroked-button color="primary" (click)="push_fragment_line_to_fragment_form('', '')">
               Add New Fragment Line
@@ -316,11 +312,6 @@
           ><br />
           <!-- This piece of code allows users to provide content for the fragment. It contains simple text fields
                 which communicate directly with the fragment_form. -->
-          <div class="alert alert-info" role="alert">
-            You can press <b>SHIFT</b> for the popup keyboard to reveal more metre and HTML possibilities. Furthermore,
-            text fields can be enlarged if needs be.
-          </div>
-
           <form [formGroup]="fragment_form">
             <mat-form-field class="input-form-full-width">
               <mat-label><b>Fragment translation</b></mat-label>

--- a/Angular/src/app/dashboard/dashboard.component.ts
+++ b/Angular/src/app/dashboard/dashboard.component.ts
@@ -265,25 +265,29 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
       'author',
       'title',
       'editor',
-      'translation',
-      'differences',
-      'commentary',
-      'apparatus',
-      'reconstruction',
-      'metrical_analysis',
       'status',
       'lock',
       'published',
     ]) {
       this.fragment_form.patchValue({ [item]: fragment[item] });
     }
-
+    // Update the fragment form with the commentary of the given fragment
+    for (const item of [
+      'translation',
+      'differences',
+      'commentary',
+      'apparatus',
+      'reconstruction',
+      'metrical_analysis',
+    ]) {
+      this.fragment_form.patchValue({ [item]: fragment.commentary[item] });
+    }
     // Fill the fragment context array
-    for (const i in fragment.context) {
+    for (const i in fragment.commentary.context) {
       this.push_fragment_context_to_fragment_form(
-        fragment.context[i].author,
-        fragment.context[i].location,
-        fragment.context[i].text
+        fragment.commentary.context[i].author,
+        fragment.commentary.context[i].location,
+        fragment.commentary.context[i].text
       );
     }
     // Fill the fragment lines array

--- a/Angular/src/app/dashboard/dashboard.component.ts
+++ b/Angular/src/app/dashboard/dashboard.component.ts
@@ -146,10 +146,9 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   ngOnInit(): void {
-    if (environment.debug) {
-      this.api.request_fragments(255, 'Ennius', 'Thyestes', 'TRF', '112');
-    }
-
+    //if (environment.debug) {
+    //this.api.request_fragments(255, 'Ennius', 'Thyestes', 'TRF', '112');
+    //}
     if (!environment.production) {
       // Only load if the environment is development: otherwise Commentary will load
       // because direct Dashboard route does not exist.

--- a/Angular/src/app/dashboard/dashboard.component.ts
+++ b/Angular/src/app/dashboard/dashboard.component.ts
@@ -259,16 +259,7 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   private convert_Fragment_to_fragment_form(fragment: Fragment): void {
     // This functions updates the fragment_form with the provided fragment
-    for (const item of [
-      '_id',
-      'name',
-      'author',
-      'title',
-      'editor',
-      'status',
-      'lock',
-      'published',
-    ]) {
+    for (const item of ['_id', 'name', 'author', 'title', 'editor', 'status', 'lock', 'published']) {
       this.fragment_form.patchValue({ [item]: fragment[item] });
     }
     // Update the fragment form with the commentary of the given fragment

--- a/Angular/src/app/dashboard/dashboard.component.ts
+++ b/Angular/src/app/dashboard/dashboard.component.ts
@@ -146,6 +146,10 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   ngOnInit(): void {
+    if (environment.debug) {
+      this.api.request_fragments(255, 'Ennius', 'Thyestes', 'TRF', '112');
+    }
+
     if (!environment.production) {
       // Only load if the environment is development: otherwise Commentary will load
       // because direct Dashboard route does not exist.
@@ -205,7 +209,7 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
    * @author Ycreak
    */
   public test(thing: any): void {
-    console.log(this.retrieved_users, thing);
+    console.log(this.fragment_form, thing);
   }
 
   /**
@@ -242,13 +246,11 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
   /**
    * Converts the fragment_form (formgroup) to the Fragment object
    * @param fragment_form to be converted
-   * @returns Fragment object
+   * @returns object representing a json blob for the server
    * @author Ycreak
    */
   private convert_fragment_form_to_Fragment(fragment_form: FormGroup): Fragment {
-    const new_fragment = new Fragment({});
-    new_fragment.set_fragment(fragment_form.value);
-    return new_fragment;
+    return fragment_form.value;
   }
 
   /**

--- a/Angular/src/app/fragments/fragments.component.html
+++ b/Angular/src/app/fragments/fragments.component.html
@@ -161,7 +161,7 @@
         </div>
         <ng-container *ngIf="given_column.fragments_translated; else fragments_not_translated">
           <div>
-            <p [innerHTML]="fragment.translation"></p>
+            <p [innerHTML]="fragment.commentary.translation"></p>
           </div>
         </ng-container>
         <ng-template #fragments_not_translated>

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -54,7 +54,7 @@ export class FragmentsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.api.request_authors_titles_editors_blob();
-  this.api.request_zotero_data();
+    this.api.request_zotero_data();
     // Create an empty current_fragment variable to be filled whenever the user clicks a fragment
     this.current_fragment = new Fragment({});
     // Create a commentary column (deprecated -> can be replaced by simple linked_fragments list)

--- a/Angular/src/app/fragments/fragments.component.ts
+++ b/Angular/src/app/fragments/fragments.component.ts
@@ -34,7 +34,7 @@ import { Column } from '@oscc/models/Column';
   ],
 })
 export class FragmentsComponent implements OnInit, OnDestroy {
-  @Output() new_commentary = new EventEmitter<Fragment>();
+  @Output() clicked_fragment = new EventEmitter<Fragment>();
 
   public current_fragment: Fragment; // Variable to store the clicked fragment and its data
   fragment_clicked = false; // Shows "click a fragment" banner at startup if nothing is yet selected
@@ -54,6 +54,7 @@ export class FragmentsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.api.request_authors_titles_editors_blob();
+  this.api.request_zotero_data();
     // Create an empty current_fragment variable to be filled whenever the user clicks a fragment
     this.current_fragment = new Fragment({});
     // Create a commentary column (deprecated -> can be replaced by simple linked_fragments list)
@@ -75,7 +76,7 @@ export class FragmentsComponent implements OnInit, OnDestroy {
     this.fragments_subscription = this.api.new_fragments_alert$.subscribe((column_id) => {
       let fragments: Fragment[] = this.api.fragments;
       for (const i in fragments) {
-        fragments[i].add_html_to_commentary();
+        fragments[i].add_html_to_lines();
       }
       // A new list of fragments has arrived. Use the column identifier to find the corresponding column
       const column = this.column_handler.columns.find((x) => x.column_id == column_id);
@@ -110,7 +111,7 @@ export class FragmentsComponent implements OnInit, OnDestroy {
   protected handle_fragment_click(fragment: Fragment, column: Column): void {
     //TODO: we need to emit a commentary object to the commentary
     fragment.fragments_translated = column.fragments_translated;
-    this.new_commentary.emit(fragment);
+    this.clicked_fragment.emit(fragment);
 
     //this.fragment_clicked2.emit(fragment);
     this.fragment_clicked = true;

--- a/Angular/src/app/models/Column.ts
+++ b/Angular/src/app/models/Column.ts
@@ -57,7 +57,7 @@ export class Column {
   // Checks if the column is able to show fragment translations
   has_translations(): boolean {
     for (const i in this.fragments) {
-      if (this.fragments[i].translation) {
+      if (this.fragments[i].commentary.translation) {
         return true;
       }
     }

--- a/Angular/src/app/models/Commentary.ts
+++ b/Angular/src/app/models/Commentary.ts
@@ -1,8 +1,11 @@
 import { Bib } from '@oscc/models/Bib';
-import { Context } from './Context';
-import { Line } from './Line';
+import { Context } from '@oscc/models/Context';
+import { Line } from '@oscc/models/Line';
 
-/** This class represents a fragment and all its data fields */
+/**
+ * This class represents a commentary and all its data fields.
+ * It is linked to a document. For example: a fragment has a commentary
+ */
 export class Commentary {
   translation = '';
   commentary = '';

--- a/Angular/src/app/models/Commentary.ts
+++ b/Angular/src/app/models/Commentary.ts
@@ -1,0 +1,173 @@
+import { Bib } from '@oscc/models/Bib';
+import { Context } from './Context';
+import { Line } from './Line';
+
+/** This class represents a fragment and all its data fields */
+export class Commentary {
+  translation: string;
+  commentary: string;
+  apparatus: string;
+  reconstruction: string;
+  differences: string;
+  metrical_analysis: string;
+  context: Context[];
+
+  lines: Line[] = [];
+
+  /**
+   * Converts the JSON received from the server to a Typescript object
+   * @param fragment with JSON data received from the server
+   * @author Ycreak
+   */
+  public set(fragment: any) {
+    this.translation = 'translation' in fragment ? fragment['translation'] : '';
+    this.commentary = 'commentary' in fragment ? fragment['commentary'] : '';
+    this.apparatus = 'apparatus' in fragment ? fragment['apparatus'] : '';
+    this.reconstruction = 'reconstruction' in fragment ? fragment['reconstruction'] : '';
+    this.differences = 'differences' in fragment ? fragment['differences'] : '';
+    this.metrical_analysis = 'metrical_analysis' in fragment ? fragment['metrical_analysis'] : '';
+    this.context = 'context' in fragment ? fragment['context'] : [];
+  }
+
+  /**
+   * This function adds HTML to the lines of the given array. At the moment,
+   * it converts white space encoding for every applicable line by looping through
+   * all elements in a fragment list.
+   * @param array with fragments as retrieved from the server
+   * @returns updated array with nice HTML formatting included
+   * @author Ycreak
+   * @TODO: this function needs to be handled by the API when retrieving the fragments
+   */
+  public add_html(): void {
+    for (const item in this.lines) {
+      // Loop through all lines of current fragment
+      let line_text = this.lines[item].text;
+      line_text = this.convert_whitespace_encoding(line_text);
+      // Now push the updated lines to the correct place
+      const updated_lines = {
+        line_number: this.lines[item].line_number,
+        text: line_text,
+      };
+      this.lines[item] = updated_lines;
+    }
+    // replaces the summary tag with summary CSS class for each commentary field
+    this.apparatus = this.convert_custom_tag_to_html(this.apparatus);
+    this.differences = this.convert_custom_tag_to_html(this.differences);
+    this.translation = this.convert_custom_tag_to_html(this.translation);
+    this.commentary = this.convert_custom_tag_to_html(this.commentary);
+    this.reconstruction = this.convert_custom_tag_to_html(this.reconstruction);
+    this.metrical_analysis = this.convert_custom_tag_to_html(this.metrical_analysis);
+  }
+
+  /**
+   * Converts the custom tags in the given blob of text to html
+   * @param string with text blob possibly containing custom tags
+   * @returns string with the custom tags replaced with corresponding html
+   * @author Ycreak
+   */
+  private convert_custom_tag_to_html(given_string: string): string {
+    if (given_string != '' && given_string != null) {
+      // Convert the summary tags
+      given_string = given_string.replace(/\[summary\]([\s\S]*?)\[\/summary\]/gm, '<div class="summary">$1</div>');
+    }
+    return given_string;
+  }
+
+  /**
+   * Converts bib references to proper html
+   * @param string that needs bib entries handled
+   * @returns string with bib entries handled
+   * @author Ycreak
+   */
+  public convert_bib_entries(zotero: Bib[]): void {
+    // TODO: needs to be reworked in the commentary rewrite
+    this.differences = this.convert_bib_entry(this.differences, zotero);
+    this.commentary = this.convert_bib_entry(this.commentary, zotero);
+    this.apparatus = this.convert_bib_entry(this.apparatus, zotero);
+    this.reconstruction = this.convert_bib_entry(this.reconstruction, zotero);
+    this.translation = this.convert_bib_entry(this.translation, zotero);
+
+    for( const i in this.context ) {
+      this.context[i].text = this.convert_bib_entry(this.context[i].text, zotero);
+    }
+  }
+
+  /**
+   * Converts all Zotero cite entries in a blob of text to proper citations
+   * @param string of text blob with (possibly) Zotero entries
+   * @param Bib[] containing all Zotero entries in our bibliopgraphy
+   * @returns string with its Zotero entries converted
+   * @author Ycreak
+   */
+  private convert_bib_entry(given_string: string, zotero: Bib[]): string {
+    if (given_string != '' && given_string != null) {
+      let from_page = '';
+      let to_page = '';
+      let bib_key = '';
+      let full_tag = '';
+      let html = '';
+
+      // Convert the bibliography items.
+      // TODO: we should let zotero convert the fields into a nice string.
+      const bib_regex = /\[bib-([\s\S]*?)\]/gm;
+      const bib_entries = [...given_string.matchAll(bib_regex)];
+      if (bib_entries?.length) {
+        bib_entries.forEach((entry) => {
+          full_tag = entry[0];
+          const values = entry[1].split('-');
+          bib_key = values[0];
+          const bib_item = zotero.find((o) => o.key === bib_key);
+          if (values.length > 2) {
+            from_page = values[1];
+            to_page = values[2];
+            html = `(${bib_item.creators[0].lastname}, ${bib_item.date}: ${from_page}-${to_page})`;
+          } else if (values.length > 1) {
+            from_page = values[1];
+            html = `(${bib_item.creators[0].lastname}, ${bib_item.date}: ${from_page})`;
+          } else {
+            html = `(${bib_item.creators[0].lastname}, ${bib_item.date})`;
+          }
+          given_string = given_string.replace(full_tag, html);
+        });
+      }
+    }
+    return given_string;
+  }
+
+  /**
+   * Takes a string and looks for whitespace decoding. Converts it to html spans
+   * @param string that needs whitespaces converted to html spans
+   * @returns string with whitespaces converted to html spans
+   * @author Ycreak
+   */
+  private convert_whitespace_encoding(string: string): string {
+    // Find fish hooks with number in between.
+    const matches = string.match(/<(\d+)>/);
+    // If found, replace it with the correct whitespace number
+    if (matches) {
+      console.log(matches);
+      // Create a span with the number of indents we want. Character level.
+      // matches[0] contains including fish hooks, matches[1] only number
+      const replacement = '<span style="padding-left:' + matches[1] + 'ch;"></span>';
+      string = string.replace(matches[0], replacement);
+    }
+    return string;
+  }
+
+  /**
+   * Returns true if the given fragment has one of its content fields filled
+   * @param fragment to be investigated for content
+   * @returns boolean whether content is present
+   * @author Ycreak
+   */
+  public has_content() {
+    return (
+      this.differences != ''
+      || this.apparatus != ''
+      || this.translation != ''
+      || this.commentary != ''
+      || this.reconstruction != ''
+    )
+  }
+}
+

--- a/Angular/src/app/models/Commentary.ts
+++ b/Angular/src/app/models/Commentary.ts
@@ -87,7 +87,7 @@ export class Commentary {
     this.reconstruction = this.convert_bib_entry(this.reconstruction, zotero);
     this.translation = this.convert_bib_entry(this.translation, zotero);
 
-    for( const i in this.context ) {
+    for (const i in this.context) {
       this.context[i].text = this.convert_bib_entry(this.context[i].text, zotero);
     }
   }
@@ -162,12 +162,11 @@ export class Commentary {
    */
   public has_content() {
     return (
-      this.differences != ''
-      || this.apparatus != ''
-      || this.translation != ''
-      || this.commentary != ''
-      || this.reconstruction != ''
-    )
+      this.differences != '' ||
+      this.apparatus != '' ||
+      this.translation != '' ||
+      this.commentary != '' ||
+      this.reconstruction != ''
+    );
   }
 }
-

--- a/Angular/src/app/models/Commentary.ts
+++ b/Angular/src/app/models/Commentary.ts
@@ -4,15 +4,20 @@ import { Line } from './Line';
 
 /** This class represents a fragment and all its data fields */
 export class Commentary {
-  translation: string;
-  commentary: string;
-  apparatus: string;
-  reconstruction: string;
-  differences: string;
-  metrical_analysis: string;
-  context: Context[];
+  translation = '';
+  commentary = '';
+  apparatus = '';
+  reconstruction = '';
+  differences = '';
+  metrical_analysis = '';
+  context: Context[] = [];
 
   lines: Line[] = [];
+
+  constructor(commentary?: Partial<Commentary>) {
+    // Allow the partial initialisation of a fragment object
+    Object.assign(this, commentary);
+  }
 
   /**
    * Converts the JSON received from the server to a Typescript object
@@ -20,13 +25,18 @@ export class Commentary {
    * @author Ycreak
    */
   public set(fragment: any) {
-    this.translation = 'translation' in fragment ? fragment['translation'] : '';
-    this.commentary = 'commentary' in fragment ? fragment['commentary'] : '';
-    this.apparatus = 'apparatus' in fragment ? fragment['apparatus'] : '';
-    this.reconstruction = 'reconstruction' in fragment ? fragment['reconstruction'] : '';
-    this.differences = 'differences' in fragment ? fragment['differences'] : '';
-    this.metrical_analysis = 'metrical_analysis' in fragment ? fragment['metrical_analysis'] : '';
-    this.context = 'context' in fragment ? fragment['context'] : [];
+    if (fragment.name == '112') {
+      console.log('fr', fragment);
+    }
+    this.translation = 'translation' in fragment && fragment['translation'] != null ? fragment['translation'] : '';
+    this.commentary = 'commentary' in fragment && fragment['commentary'] != null ? fragment['commentary'] : '';
+    this.apparatus = 'apparatus' in fragment && fragment['apparatus'] != null ? fragment['apparatus'] : '';
+    this.reconstruction =
+      'reconstruction' in fragment && fragment['reconstruction'] != null ? fragment['reconstruction'] : '';
+    this.differences = 'differences' in fragment && fragment['differences'] != null ? fragment['differences'] : '';
+    this.metrical_analysis =
+      'metrical_analysis' in fragment && fragment['metrical_analysis'] != null ? fragment['metrical_analysis'] : '';
+    this.context = 'context' in fragment && fragment['context'] != null ? fragment['context'] : [];
   }
 
   /**

--- a/Angular/src/app/models/Fragment.ts
+++ b/Angular/src/app/models/Fragment.ts
@@ -1,4 +1,3 @@
-import { Context } from './Context';
 import { Commentary } from './Commentary';
 import { Line } from './Line';
 import { Linked_fragment } from './Linked_fragment';
@@ -45,9 +44,9 @@ export class Fragment {
    * @author Ycreak
    */
   public set_fragment(fragment: any) {
-    this.commentary = new Commentary;
+    this.commentary = new Commentary();
     this.commentary.set(fragment);
-    
+
     this._id = '_id' in fragment ? fragment['_id'] : '';
     this.author = 'author' in fragment ? fragment['author'] : '';
     this.title = 'title' in fragment ? fragment['title'] : '';
@@ -59,7 +58,7 @@ export class Fragment {
     this.lock = 'lock' in fragment ? fragment['lock'] : '';
     this.published = '' in fragment ? fragment['published'] : '';
   }
-  
+
   /**
    * This function adds HTML to the lines of the given array. At the moment,
    * it converts white space encoding for every applicable line by looping through

--- a/Angular/src/app/models/Fragment.ts
+++ b/Angular/src/app/models/Fragment.ts
@@ -1,6 +1,6 @@
-import { Commentary } from './Commentary';
-import { Line } from './Line';
-import { Linked_fragment } from './Linked_fragment';
+import { Commentary } from '@oscc/models/Commentary';
+import { Line } from '@oscc/models/Line';
+import { Linked_fragment } from '@oscc/models/Linked_fragment';
 
 /** This class represents a fragment and all its data fields */
 export class Fragment {
@@ -36,9 +36,6 @@ export class Fragment {
    * @author Ycreak
    */
   public set_fragment(fragment: any) {
-    this.commentary = new Commentary({});
-    this.commentary.set(fragment);
-
     this._id = '_id' in fragment ? fragment['_id'] : '';
     this.author = 'author' in fragment ? fragment['author'] : '';
     this.title = 'title' in fragment ? fragment['title'] : '';
@@ -49,6 +46,10 @@ export class Fragment {
     this.linked_fragments = 'linked_fragments' in fragment ? fragment['linked_fragments'] : [];
     this.lock = 'lock' in fragment ? fragment['lock'] : '';
     this.published = '' in fragment ? fragment['published'] : '';
+
+    this.commentary = new Commentary({});
+    this.commentary.set(fragment);
+    this.commentary.lines = this.lines;
   }
 
   /**

--- a/Angular/src/app/models/Fragment.ts
+++ b/Angular/src/app/models/Fragment.ts
@@ -4,28 +4,20 @@ import { Linked_fragment } from './Linked_fragment';
 
 /** This class represents a fragment and all its data fields */
 export class Fragment {
+  // Meta data
   _id = '';
   author = '';
   title = '';
   editor = '';
   name = '';
-
-  commentary: Commentary;
-
-  //translation: string;
-  //commentary: string;
-  //apparatus: string;
-  //reconstruction: string;
-  //differences: string;
-  //metrical_analysis: string;
-  //context: Context[];
-
-  // Keeps track whether we tranlated this fragment using the column translate functionality
-  fragments_translated = false;
-
   status = '';
+  // Commentary
+  commentary: Commentary;
+  // Content
   lines: Line[] = [];
   linked_fragments: Linked_fragment[] = [];
+  // Keeps track whether we tranlated this fragment using the column translate functionality
+  fragments_translated = false;
 
   lock = '';
   published = '';
@@ -44,7 +36,7 @@ export class Fragment {
    * @author Ycreak
    */
   public set_fragment(fragment: any) {
-    this.commentary = new Commentary();
+    this.commentary = new Commentary({});
     this.commentary.set(fragment);
 
     this._id = '_id' in fragment ? fragment['_id'] : '';

--- a/Angular/src/app/models/Fragment.ts
+++ b/Angular/src/app/models/Fragment.ts
@@ -1,7 +1,7 @@
 import { Context } from './Context';
+import { Commentary } from './Commentary';
 import { Line } from './Line';
 import { Linked_fragment } from './Linked_fragment';
-import { Bib } from '@oscc/models/Bib';
 
 /** This class represents a fragment and all its data fields */
 export class Fragment {
@@ -11,15 +11,17 @@ export class Fragment {
   editor = '';
   name = '';
 
-  translation: string;
-  commentary: string;
-  apparatus: string;
-  reconstruction: string;
-  differences: string;
-  metrical_analysis: string;
-  context: Context[];
+  commentary: Commentary;
 
-  // TODO: this needs to be part of the commentary object
+  //translation: string;
+  //commentary: string;
+  //apparatus: string;
+  //reconstruction: string;
+  //differences: string;
+  //metrical_analysis: string;
+  //context: Context[];
+
+  // Keeps track whether we tranlated this fragment using the column translate functionality
   fragments_translated = false;
 
   status = '';
@@ -28,8 +30,6 @@ export class Fragment {
 
   lock = '';
   published = '';
-
-  bibliography: string[];
 
   // designates the css color of the fragment header
   colour = 'black';
@@ -45,49 +45,21 @@ export class Fragment {
    * @author Ycreak
    */
   public set_fragment(fragment: any) {
-    this.translation = 'translation' in fragment ? fragment['translation'] : '';
-    this.commentary = 'commentary' in fragment ? fragment['commentary'] : '';
-    this.apparatus = 'apparatus' in fragment ? fragment['apparatus'] : '';
-    this.reconstruction = 'reconstruction' in fragment ? fragment['reconstruction'] : '';
-    this.differences = 'differences' in fragment ? fragment['differences'] : '';
-    this.metrical_analysis = 'metrical_analysis' in fragment ? fragment['metrical_analysis'] : '';
-    this.context = 'context' in fragment ? fragment['context'] : [];
-
-    if ('_id' in fragment) {
-      this._id = fragment['_id'];
-    }
-    if ('author' in fragment) {
-      this.author = fragment['author'];
-    }
-    if ('title' in fragment) {
-      this.title = fragment['title'];
-    }
-    if ('editor' in fragment) {
-      this.editor = fragment['editor'];
-    }
-    if ('name' in fragment) {
-      this.name = fragment['name'];
-    }
-    if ('status' in fragment) {
-      this.status = fragment['status'];
-    }
-    if ('lines' in fragment) {
-      this.lines = fragment['lines'];
-    }
-    if ('linked_fragments' in fragment) {
-      this.linked_fragments = fragment['linked_fragments'];
-    }
-    if ('lock' in fragment) {
-      this.lock = fragment['lock'];
-    }
-    if ('published' in fragment) {
-      this.published = fragment['published'];
-    }
-    if ('bibliography' in fragment) {
-      this.bibliography = fragment['bibliography'];
-    }
+    this.commentary = new Commentary;
+    this.commentary.set(fragment);
+    
+    this._id = '_id' in fragment ? fragment['_id'] : '';
+    this.author = 'author' in fragment ? fragment['author'] : '';
+    this.title = 'title' in fragment ? fragment['title'] : '';
+    this.editor = 'editor' in fragment ? fragment['editor'] : '';
+    this.name = 'name' in fragment ? fragment['name'] : '';
+    this.status = 'status' in fragment ? fragment['status'] : '';
+    this.lines = 'lines' in fragment ? fragment['lines'] : [];
+    this.linked_fragments = 'linked_fragments' in fragment ? fragment['linked_fragments'] : [];
+    this.lock = 'lock' in fragment ? fragment['lock'] : '';
+    this.published = '' in fragment ? fragment['published'] : '';
   }
-
+  
   /**
    * This function adds HTML to the lines of the given array. At the moment,
    * it converts white space encoding for every applicable line by looping through
@@ -95,9 +67,8 @@ export class Fragment {
    * @param array with fragments as retrieved from the server
    * @returns updated array with nice HTML formatting included
    * @author Ycreak
-   * @TODO: this function needs to be handled by the API when retrieving the fragments
    */
-  public add_html_to_commentary(): void {
+  public add_html_to_lines(): void {
     for (const item in this.lines) {
       // Loop through all lines of current fragment
       let line_text = this.lines[item].text;
@@ -109,77 +80,6 @@ export class Fragment {
       };
       this.lines[item] = updated_lines;
     }
-    // replaces the summary tag with summary CSS class for each commentary field
-    this.apparatus = this.convert_custom_tag_to_html(this.apparatus);
-    this.differences = this.convert_custom_tag_to_html(this.differences);
-    this.translation = this.convert_custom_tag_to_html(this.translation);
-    this.commentary = this.convert_custom_tag_to_html(this.commentary);
-    this.reconstruction = this.convert_custom_tag_to_html(this.reconstruction);
-    this.metrical_analysis = this.convert_custom_tag_to_html(this.metrical_analysis);
-  }
-
-  /**
-   * Converts the custom tags in the given blob of text to html
-   * @param string with text blob possibly containing custom tags
-   * @returns string with the custom tags replaced with corresponding html
-   * @author Ycreak
-   */
-  private convert_custom_tag_to_html(given_string: string): string {
-    if (given_string != '' && given_string != null) {
-      // Convert the summary tags
-      given_string = given_string.replace(/\[summary\]([\s\S]*?)\[\/summary\]/gm, '<div class="summary">$1</div>');
-    }
-    return given_string;
-  }
-
-  /**
-   * Converts bib references to proper html
-   * @param string that needs bib entries handled
-   * @returns string with bib entries handled
-   * @author Ycreak
-   */
-  public convert_bib_entries(zotero: Bib[]): void {
-    // TODO: needs to be reworked in the commentary rewrite
-    this.differences = this.convert_bib_entry(this.differences, zotero);
-    this.commentary = this.convert_bib_entry(this.commentary, zotero);
-    this.apparatus = this.convert_bib_entry(this.apparatus, zotero);
-    this.reconstruction = this.convert_bib_entry(this.reconstruction, zotero);
-    this.translation = this.convert_bib_entry(this.translation, zotero);
-  }
-
-  private convert_bib_entry(given_string: string, zotero: Bib[]): string {
-    if (given_string != '' && given_string != null) {
-      let from_page = '';
-      let to_page = '';
-      let bib_key = '';
-      let full_tag = '';
-      let html = '';
-
-      // Convert the bibliography items.
-      // TODO: we should let zotero convert the fields into a nice string.
-      const bib_regex = /\[bib-([\s\S]*?)\]/gm;
-      const bib_entries = [...given_string.matchAll(bib_regex)];
-      if (bib_entries?.length) {
-        bib_entries.forEach((entry) => {
-          full_tag = entry[0];
-          const values = entry[1].split('-');
-          bib_key = values[0];
-          const bib_item = zotero.find((o) => o.key === bib_key);
-          if (values.length > 2) {
-            from_page = values[1];
-            to_page = values[2];
-            html = `(${bib_item.creators[0].lastname}, ${bib_item.date}: pp.${from_page}-${to_page})`;
-          } else if (values.length > 1) {
-            from_page = values[1];
-            html = `(${bib_item.creators[0].lastname}, ${bib_item.date}: p.${from_page})`;
-          } else {
-            html = `(${bib_item.creators[0].lastname}, ${bib_item.date})`;
-          }
-          given_string = given_string.replace(full_tag, html);
-        });
-      }
-    }
-    return given_string;
   }
 
   /**
@@ -201,27 +101,4 @@ export class Fragment {
     }
     return string;
   }
-
-  /**
-   * Returns true if the given fragment has one of its content fields filled
-   * @param fragment to be investigated for content
-   * @returns boolean whether content is present
-   * @author Ycreak
-   */
-  public has_content() {
-    if (
-      this.differences != '' ||
-      this.apparatus != '' ||
-      this.translation != '' ||
-      this.commentary != '' ||
-      this.reconstruction != ''
-    ) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  // deprecated
-  fragment_link_found = false;
 }

--- a/Angular/src/app/overview/overview.component.html
+++ b/Angular/src/app/overview/overview.component.html
@@ -78,7 +78,7 @@
 <div>
   <mat-drawer-container class="drawer-container" autosize>
     <div class="overview-sidenav-content">
-      <app-fragments (new_commentary)="this.current_fragment = $event"> </app-fragments>
+      <app-fragments (clicked_fragment)="this.clicked_fragment = $event"> </app-fragments>
     </div>
 
     <hr />
@@ -91,9 +91,37 @@
       position="end"
       opened="true">
       <div style="padding: 0.5em">
-        <app-commentary #commentary [current_fragment]="this.current_fragment"> </app-commentary>
+        <!--Show the currently clicked author + title-->
+        <div *ngIf="!this.fragment_is_clicked(); else fragment_clicked">
+          <h5>Click a fragment to show its content.</h5>
+        </div>
+        <ng-template #fragment_clicked>
+          <h5>
+            Selected
+            <a class="a-void" (click)="this.introductions.show_introduction_dialog(this.clicked_fragment.author)">{{
+              this.clicked_fragment.author
+            }}</a
+            >,
+            <a class="a-void" (click)="this.introductions.show_introduction_dialog(this.clicked_fragment.title)">{{
+              this.clicked_fragment.title
+            }}</a
+            >, {{ this.clicked_fragment.editor }},
+            {{ this.clicked_fragment.name }}
+          </h5>
+
+          <!-- Show banner if no commentary available -->
+          <div *ngIf="!this.clicked_fragment.commentary.has_content()" class="alert alert-info" role="alert">
+            No content is available yet for this specific fragment.
+          </div>
+          <!--Show the commentary via the commentary component -->
+          <app-commentary *ngIf="this.clicked_fragment.commentary.has_content()" #commentary 
+            [commentary]="this.clicked_fragment.commentary"
+            [fragments_translated]="this.clicked_fragment.fragments_translated"> 
+          </app-commentary>
+        </ng-template>
+       
       </div>
     </mat-drawer>
   </mat-drawer-container>
-  <app-playground *ngIf="this.playground_enabled" (fragment_clicked)="this.current_fragment = $event"></app-playground>
+  <app-playground *ngIf="this.playground_enabled" (clicked_fragment)="this.clicked_fragment = $event"></app-playground>
 </div>

--- a/Angular/src/app/overview/overview.component.html
+++ b/Angular/src/app/overview/overview.component.html
@@ -114,12 +114,13 @@
             No content is available yet for this specific fragment.
           </div>
           <!--Show the commentary via the commentary component -->
-          <app-commentary *ngIf="this.clicked_fragment.commentary.has_content()" #commentary 
+          <app-commentary
+            *ngIf="this.clicked_fragment.commentary.has_content()"
+            #commentary
             [commentary]="this.clicked_fragment.commentary"
-            [fragments_translated]="this.clicked_fragment.fragments_translated"> 
+            [fragments_translated]="this.clicked_fragment.fragments_translated">
           </app-commentary>
         </ng-template>
-       
       </div>
     </mat-drawer>
   </mat-drawer-container>

--- a/Angular/src/app/overview/overview.component.ts
+++ b/Angular/src/app/overview/overview.component.ts
@@ -103,14 +103,14 @@ export class OverviewComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Function to check whether a fragment has been clicked 
+   * Function to check whether a fragment has been clicked
    * @returns boolean
    * @author Ycreak
    */
   protected fragment_is_clicked(): boolean {
     return this.clicked_fragment.author != '';
   }
-  
+
   /**
    * Returns the title from the environment for the frontend to print
    * @param kind to print: either long or short

--- a/Angular/src/app/overview/overview.component.ts
+++ b/Angular/src/app/overview/overview.component.ts
@@ -35,7 +35,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
   protected commentary_enabled = true;
   protected playground_enabled = true;
 
-  protected current_fragment: Fragment;
+  protected clicked_fragment: Fragment;
 
   constructor(
     protected api: ApiService,
@@ -53,7 +53,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     // Create the window watcher for mobile devices
     this.window_watcher.init(window.innerWidth);
-    this.current_fragment = new Fragment({});
+    this.clicked_fragment = new Fragment({});
 
     // Load the user's previously used setting from local storage using the LocalStorageService service
     this.settings.load_settings();
@@ -102,6 +102,15 @@ export class OverviewComponent implements OnInit, OnDestroy {
     this.matdialog.open(LoginComponent, {});
   }
 
+  /**
+   * Function to check whether a fragment has been clicked 
+   * @returns boolean
+   * @author Ycreak
+   */
+  protected fragment_is_clicked(): boolean {
+    return this.clicked_fragment.author != '';
+  }
+  
   /**
    * Returns the title from the environment for the frontend to print
    * @param kind to print: either long or short

--- a/Angular/src/app/playground/playground.component.ts
+++ b/Angular/src/app/playground/playground.component.ts
@@ -52,7 +52,7 @@ export class PlaygroundComponent implements OnInit, OnDestroy, AfterViewInit {
       if (column_id == environment.playground_id) {
         const fragments = this.api.fragments;
         for (const i in fragments) {
-          fragments[i].add_html_to_commentary();
+          fragments[i].add_html_to_lines();
         }
         if (this.single_fragment_requested) {
           this.playground.fragments.push(fragments[0]);

--- a/Angular/src/environments/environment.prod.ts
+++ b/Angular/src/environments/environment.prod.ts
@@ -9,5 +9,6 @@ export const environment = {
   current_user_name: '',
   current_user_role: 'guest',
   production: true,
-  zotero_url: "https://api.zotero.org/groups/5089557/items?v=3"
+  zotero_url: "https://api.zotero.org/groups/5089557/items?v=3",
+  debug: false
 };

--- a/Angular/src/environments/environment.prod.ts
+++ b/Angular/src/environments/environment.prod.ts
@@ -9,4 +9,5 @@ export const environment = {
   current_user_name: '',
   current_user_role: 'guest',
   production: true,
+  zotero_url: "https://api.zotero.org/groups/5089557/items?v=3"
 };

--- a/Angular/src/environments/environment.ts
+++ b/Angular/src/environments/environment.ts
@@ -13,5 +13,6 @@ export const environment = {
   current_user_name: 'Lucus',
   current_user_role: 'teacher',
   production: false,
-  zotero_url: "https://api.zotero.org/groups/5089557/items?v=3"
+  zotero_url: "https://api.zotero.org/groups/5089557/items?v=3",
+  debug: true,
 };

--- a/Angular/src/environments/environment.ts
+++ b/Angular/src/environments/environment.ts
@@ -13,4 +13,5 @@ export const environment = {
   current_user_name: 'Lucus',
   current_user_role: 'teacher',
   production: false,
+  zotero_url: "https://api.zotero.org/groups/5089557/items?v=3"
 };


### PR DESCRIPTION
The commentary is now its own object. This means that each fragment has a commentary, which is of type Commentary. This commentary has a translation, commentary (i know), reconstruction etc. The advantage of this is that we can give the commentary component a commentary and nothing else. Also very useful when we want to extend beyond only fragments: epigrams might have other fields: this will prevent clutter in the long run.

**Functional test**
- [ ] Test if the OSCC still functions, especially around parts dealing with the commentary