### PR TITLE
"Show more" fadeout in commentary cuts into outline of summary.

### DIFF
--- a/Angular/src/app/other_components/expandable-text/expandable-text.component.scss
+++ b/Angular/src/app/other_components/expandable-text/expandable-text.component.scss
@@ -5,6 +5,7 @@ div.collapsed-text-container {
 %collapsed-text {
   max-height: var(--collapsed-height);
   overflow: hidden;
+  padding: 0px 1px 0px 1px; // Avoids some text elements like summaries from being cut off
 }
 
 div.collapsed-text {


### PR DESCRIPTION
Fixes #158

Simple css fix