### PR TITLE
Fragment copy

### DIFF
--- a/Angular/src/app/app.module.ts
+++ b/Angular/src/app/app.module.ts
@@ -92,6 +92,7 @@ import { DocumentFilterComponent } from './dialogs/document-filter/document-filt
 import { UsersComponent } from './dashboard/users/users.component';
 import { TestimoniaComponent } from './columns/testimonia/testimonia.component';
 import { FragmentComponent } from './columns/fragment/fragment.component';
+import { OnCopyDirective } from './directives/on-copy.directive';
 
 // Routes to take. Disallows Path Traversal.
 const appRoutes: Routes = [
@@ -127,6 +128,7 @@ const appRoutes: Routes = [
     UsersComponent,
     TestimoniaComponent,
     FragmentComponent,
+    OnCopyDirective,
   ],
   imports: [
     BrowserModule,

--- a/Angular/src/app/columns/columns.component.html
+++ b/Angular/src/app/columns/columns.component.html
@@ -152,8 +152,9 @@
           this.generate_document_gradient_background_color(
             given_column.documents.length,
             given_column.original_fragment_order.indexOf(fragment.name)
-          )
-        ">
+          )"
+        appOnCopy
+        (copyFragment)="this.copy_fragment_content(current_fragment)">
         <div *ngIf="fragment.document_type === 'testimonium'">
           <app-testimonia [testimonium]="fragment"> </app-testimonia>
         </div>

--- a/Angular/src/app/columns/columns.component.html
+++ b/Angular/src/app/columns/columns.component.html
@@ -144,6 +144,7 @@
       <div
         class="fragment-box"
         (click)="handle_document_click(fragment, given_column)"
+        (contextmenu)="handle_document_click(fragment, given_column); onRightClick($event, this.current_fragment)"
         cdkDrag
         [cdkDragDisabled]="this.settings.fragments.dragging_disabled"
         (cdkDragDropped)="this.column_handler.track_edited_columns($event)"
@@ -165,3 +166,17 @@
     </div>
   </div>
 </ng-template>
+
+
+<!-- Context menu for right click actions on fragments -->
+<mat-menu #rightMenu="matMenu"> 
+  <ng-template matMenuContent let-item="item"> 
+    <button (click)="this.copy_fragment_content(current_fragment)" mat-menu-item>Copy text</button> 
+  </ng-template> 
+</mat-menu> 
+
+  <!-- hidden helper div used for the context menu -->
+  <div style="visibility: hidden; position: fixed;" 
+  [style.left]="menuTopLeftPosition.x" 
+  [style.top]="menuTopLeftPosition.y" 
+  [matMenuTriggerFor]="rightMenu"></div> 

--- a/Angular/src/app/columns/columns.component.html
+++ b/Angular/src/app/columns/columns.component.html
@@ -153,7 +153,8 @@
           this.generate_document_gradient_background_color(
             given_column.documents.length,
             given_column.original_fragment_order.indexOf(fragment.name)
-          )"
+          )
+        "
         appOnCopy
         (copyFragment)="this.copy_fragment_content(current_fragment)">
         <div *ngIf="fragment.document_type === 'testimonium'">
@@ -167,16 +168,16 @@
   </div>
 </ng-template>
 
-
 <!-- Context menu for right click actions on fragments -->
-<mat-menu #rightMenu="matMenu"> 
-  <ng-template matMenuContent let-item="item"> 
-    <button (click)="this.copy_fragment_content(current_fragment)" mat-menu-item>Copy text</button> 
-  </ng-template> 
-</mat-menu> 
+<mat-menu #rightMenu="matMenu">
+  <ng-template matMenuContent let-item="item">
+    <button (click)="this.copy_fragment_content(current_fragment)" mat-menu-item>Copy text</button>
+  </ng-template>
+</mat-menu>
 
-  <!-- hidden helper div used for the context menu -->
-  <div style="visibility: hidden; position: fixed;" 
-  [style.left]="menuTopLeftPosition.x" 
-  [style.top]="menuTopLeftPosition.y" 
-  [matMenuTriggerFor]="rightMenu"></div> 
+<!-- hidden helper div used for the context menu -->
+<div
+  style="visibility: hidden; position: fixed"
+  [style.left]="menuTopLeftPosition.x"
+  [style.top]="menuTopLeftPosition.y"
+  [matMenuTriggerFor]="rightMenu"></div>

--- a/Angular/src/app/columns/columns.component.ts
+++ b/Angular/src/app/columns/columns.component.ts
@@ -1,5 +1,5 @@
 // Library imports
-import { Component, OnInit, OnDestroy, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewEncapsulation, ViewChild } from '@angular/core';
 import { Output, EventEmitter } from '@angular/core';
 import { trigger, transition, style, animate } from '@angular/animations';
 import { MatDialog } from '@angular/material/dialog';
@@ -17,6 +17,7 @@ import { DocumentFilterComponent } from '@oscc/dialogs/document-filter/document-
 // Model imports
 import { Fragment } from '@oscc/models/Fragment';
 import { Column } from '@oscc/models/Column';
+import { MatMenuTrigger } from '@angular/material/menu';
 
 @Component({
   selector: 'app-columns',
@@ -270,4 +271,34 @@ export class ColumnsComponent implements OnInit, OnDestroy {
       },
     });
   }
+
+    /** 
+   * Method called when the user click with the right button
+   * Used to open a context menu as described in this component's html 
+   * @param event MouseEvent, it contains the coordinates 
+   * @param item Our data contained in the row of the table 
+   * @author sajvanwijk
+   */ 
+    // we create an object that contains coordinates 
+    menuTopLeftPosition =  {x: '0', y: '0'} 
+ 
+    // reference to the MatMenuTrigger in the DOM 
+    @ViewChild(MatMenuTrigger, {static: true}) matMenuTrigger: MatMenuTrigger; 
+
+    protected onRightClick(event: MouseEvent, item) { 
+      // preventDefault avoids to show the visualization of the right-click menu of the browser 
+      event.preventDefault(); 
+ 
+      // we record the mouse position in our object 
+      this.menuTopLeftPosition.x = event.clientX + 'px'; 
+      this.menuTopLeftPosition.y = event.clientY + 'px'; 
+ 
+      // we open the menu 
+      // we pass to the menu the information about our object 
+      this.matMenuTrigger.menuData = {item: item} 
+ 
+      // we open the menu 
+      this.matMenuTrigger.openMenu(); 
+ 
+  } 
 }

--- a/Angular/src/app/columns/columns.component.ts
+++ b/Angular/src/app/columns/columns.component.ts
@@ -136,9 +136,33 @@ export class ColumnsComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Given the document, this function checks whether its linked documents appear in the
-   * other opened columns. If so, the columns are scrolled to put the linked document in view
-   * @param document object with the linked_fragments field to be examined
+   * Helper function to find and return the textual content of a given document object
+   * @author CptVickers
+   */
+  protected copy_document_content(document): void {
+    let content = '';
+    if (!document.fragments_translated) {
+      // Parse the fragment lines into a single string
+      const fragment_lines = document.lines;
+      for (const line of fragment_lines) {
+        content += line.line_number + ': ' + line.text + '\n';
+      }
+    }
+    else {
+      content = document.translation;
+    }
+
+    // Move the result to the user's clipboard
+    navigator.clipboard.writeText(content);
+
+    // Notify the user that the text has been copied
+    this.utility.open_snackbar("Document copied!");
+  }
+
+  /**
+   * Given the fragment, this function checks whether its linked fragments appear in the
+   * other opened columns. If so, the columns are scrolled to put the linked fragment in view
+   * @param fragment object with the linked_fragments field to be examined
    * @author Ycreak
    */
   //private scroll_to_linked_fragments(document: Fragment) {

--- a/Angular/src/app/columns/columns.component.ts
+++ b/Angular/src/app/columns/columns.component.ts
@@ -148,8 +148,7 @@ export class ColumnsComponent implements OnInit, OnDestroy {
       for (const line of fragment_lines) {
         content += line.line_number + ': ' + line.text + '\n';
       }
-    }
-    else {
+    } else {
       content = document.translation;
     }
 
@@ -157,7 +156,7 @@ export class ColumnsComponent implements OnInit, OnDestroy {
     navigator.clipboard.writeText(content);
 
     // Notify the user that the text has been copied
-    this.utility.open_snackbar("Document copied!");
+    this.utility.open_snackbar('Document copied!');
   }
 
   /**

--- a/Angular/src/app/columns/columns.component.ts
+++ b/Angular/src/app/columns/columns.component.ts
@@ -66,7 +66,7 @@ export class ColumnsComponent implements OnInit, OnDestroy {
           author: 'Ennius',
           title: 'Thyestes',
           editor: 'TRF',
-        })
+        }),
       );
     }
     //this.api.request_documents(1, 'Ennius', 'Eumenides', 'TRF');
@@ -272,33 +272,32 @@ export class ColumnsComponent implements OnInit, OnDestroy {
     });
   }
 
-    /** 
+  /**
    * Method called when the user click with the right button
-   * Used to open a context menu as described in this component's html 
-   * @param event MouseEvent, it contains the coordinates 
-   * @param item Our data contained in the row of the table 
+   * Used to open a context menu as described in this component's html
+   * @param event MouseEvent, it contains the coordinates
+   * @param item Our data contained in the row of the table
    * @author sajvanwijk
-   */ 
-    // we create an object that contains coordinates 
-    menuTopLeftPosition =  {x: '0', y: '0'} 
- 
-    // reference to the MatMenuTrigger in the DOM 
-    @ViewChild(MatMenuTrigger, {static: true}) matMenuTrigger: MatMenuTrigger; 
+   */
+  // we create an object that contains coordinates
+  menuTopLeftPosition = { x: '0', y: '0' };
 
-    protected onRightClick(event: MouseEvent, item) { 
-      // preventDefault avoids to show the visualization of the right-click menu of the browser 
-      event.preventDefault(); 
- 
-      // we record the mouse position in our object 
-      this.menuTopLeftPosition.x = event.clientX + 'px'; 
-      this.menuTopLeftPosition.y = event.clientY + 'px'; 
- 
-      // we open the menu 
-      // we pass to the menu the information about our object 
-      this.matMenuTrigger.menuData = {item: item} 
- 
-      // we open the menu 
-      this.matMenuTrigger.openMenu(); 
- 
-  } 
+  // reference to the MatMenuTrigger in the DOM
+  @ViewChild(MatMenuTrigger, { static: true }) matMenuTrigger: MatMenuTrigger;
+
+  protected onRightClick(event: MouseEvent, item) {
+    // preventDefault avoids to show the visualization of the right-click menu of the browser
+    event.preventDefault();
+
+    // we record the mouse position in our object
+    this.menuTopLeftPosition.x = event.clientX + 'px';
+    this.menuTopLeftPosition.y = event.clientY + 'px';
+
+    // we open the menu
+    // we pass to the menu the information about our object
+    this.matMenuTrigger.menuData = { item: item };
+
+    // we open the menu
+    this.matMenuTrigger.openMenu();
+  }
 }

--- a/Angular/src/app/columns/columns.component.ts
+++ b/Angular/src/app/columns/columns.component.ts
@@ -66,7 +66,7 @@ export class ColumnsComponent implements OnInit, OnDestroy {
           author: 'Ennius',
           title: 'Thyestes',
           editor: 'TRF',
-        }),
+        })
       );
     }
     //this.api.request_documents(1, 'Ennius', 'Eumenides', 'TRF');

--- a/Angular/src/app/directives/on-copy.directive.spec.ts
+++ b/Angular/src/app/directives/on-copy.directive.spec.ts
@@ -1,0 +1,8 @@
+import { OnCopyDirective } from './on-copy.directive';
+
+describe('OnCopyDirective', () => {
+  it('should create an instance', () => {
+    const directive = new OnCopyDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/Angular/src/app/directives/on-copy.directive.ts
+++ b/Angular/src/app/directives/on-copy.directive.ts
@@ -1,0 +1,12 @@
+import { Directive, Output, EventEmitter, HostListener } from '@angular/core';
+
+@Directive({
+  selector: '[appOnCopy]'
+})
+export class OnCopyDirective {
+  @Output() copyFragment = new EventEmitter();
+
+  @HostListener('window:keydown.control.c') onCtrlC() {
+  this.copyFragment.emit();
+  }
+}

--- a/Angular/src/app/directives/on-copy.directive.ts
+++ b/Angular/src/app/directives/on-copy.directive.ts
@@ -1,12 +1,12 @@
 import { Directive, Output, EventEmitter, HostListener } from '@angular/core';
 
 @Directive({
-  selector: '[appOnCopy]'
+  selector: '[appOnCopy]',
 })
 export class OnCopyDirective {
   @Output() copyFragment = new EventEmitter();
 
   @HostListener('window:keydown.control.c') onCtrlC() {
-  this.copyFragment.emit();
+    this.copyFragment.emit();
   }
 }


### PR DESCRIPTION
>We can do this now! 
Both via ctrl-c and a context menu. 

Current implementation has the following 'quirks' which may or may not be what we want:
- [ ] It makes the right-clicked fragment the selected one. This was easier to implement, but may not be what we want.
- [ ] Copied fragment translations contain html tags. We might want to clear those out. 

**Furthermore**, this commit must be rebased on the latest Development at some point
- [x] Rebase this on Development

## Functional tests
- [x] Select a fragment. Then do ctrl/cmd+c. Note the snackbar message. Confirm that the text is copied.
- [x] Right-click a fragment. You should be presented nicely with the option to copy.
