### PR TITLE
Testimonia in dashboard part 1

### DIFF
--- a/Angular/src/app/api.service.ts
+++ b/Angular/src/app/api.service.ts
@@ -4,7 +4,7 @@ import { HttpClient } from '@angular/common/http';
 import { HttpErrorResponse } from '@angular/common/http';
 import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest } from '@angular/common/http';
 import { Observable, throwError, ReplaySubject, BehaviorSubject } from 'rxjs';
-import { tap, map } from 'rxjs/operators';
+import { tap } from 'rxjs/operators';
 import { environment } from '@src/environments/environment';
 
 // Service imports
@@ -14,7 +14,6 @@ import { UtilityService } from '@oscc/utility.service';
 import { Fragment } from '@oscc/models/Fragment';
 import { Testimonium } from '@oscc/models/Testimonium';
 import { Bib } from '@oscc/models/Bib';
-import { Column } from '@oscc/models/Column';
 import { User } from '@oscc/models/User';
 import { Introduction_form } from '@oscc/models/Introduction_form';
 import { DialogService } from '@oscc/services/dialog.service';
@@ -192,16 +191,13 @@ export class ApiService {
   }
 
   public request_document_names(key: any): void {
-    console.log('key', key);
-    let names: fragment_name[] = [];
+    const names: fragment_name[] = [];
     this.spinner_on();
     this.get_fragment_names(key).subscribe({
       next: (data) => {
         data.forEach((value) => {
           names.push({ name: value } as fragment_name);
         });
-        //names = this.fragment_names.sort(this.utility.sort_fragment_array_numerically);
-        console.log('data!', names);
         this.new_document_names_alert.next(names);
         this.spinner_off();
       },
@@ -262,7 +258,7 @@ export class ApiService {
     });
   }
 
-  public request_create_fragment(fragment: Fragment, column_id?: number): void {
+  public request_create_fragment(fragment: any, column_id?: number): void {
     this.spinner_on();
     this.create_fragment(fragment).subscribe({
       next: (data) => {
@@ -278,7 +274,7 @@ export class ApiService {
     });
   }
 
-  public request_revise_fragment(fragment: Fragment, column_id?: number): void {
+  public request_revise_fragment(fragment: any, column_id?: number): void {
     this.spinner_on();
     this.revise_fragment(fragment).subscribe({
       next: (data) => {
@@ -294,22 +290,15 @@ export class ApiService {
     });
   }
 
-  public request_delete_fragment(
-    author: string,
-    title: string,
-    editor: string,
-    name: string,
-    column_id?: number
-  ): void {
+  public request_delete_fragment(key: any): void {
     this.spinner_on();
-    this.fragment_key = this.create_fragment_key(author, title, editor, name);
-    this.delete_fragment(this.fragment_key).subscribe({
+    this.delete_fragment(key).subscribe({
       next: (data) => {
         this.handle_error_message(data);
         this.request_authors_titles_editors_blob();
-        if (column_id) {
-          this.request_fragment_names(column_id, author, title, editor);
-        }
+        //if (column_id) {
+        //this.request_fragment_names(column_id, author, title, editor);
+        //}
         this.spinner_off();
       },
       error: (err) => this.handle_error_message(err),

--- a/Angular/src/app/app.module.ts
+++ b/Angular/src/app/app.module.ts
@@ -93,6 +93,7 @@ import { UsersComponent } from './dashboard/users/users.component';
 import { TestimoniaComponent } from './columns/testimonia/testimonia.component';
 import { FragmentComponent } from './columns/fragment/fragment.component';
 import { OnCopyDirective } from './directives/on-copy.directive';
+import { TestimoniaDashboardComponent } from './dashboard/testimonia-dashboard/testimonia-dashboard.component';
 
 // Routes to take. Disallows Path Traversal.
 const appRoutes: Routes = [
@@ -129,6 +130,7 @@ const appRoutes: Routes = [
     TestimoniaComponent,
     FragmentComponent,
     OnCopyDirective,
+    TestimoniaDashboardComponent,
   ],
   imports: [
     BrowserModule,

--- a/Angular/src/app/dashboard/dashboard.component.html
+++ b/Angular/src/app/dashboard/dashboard.component.html
@@ -200,18 +200,17 @@
 
           <div class="alert alert-info" role="alert">
             To create a new fragment, please provide all meta data and press the <b>Create Fragment</b> button. The
-            button wont activate before all meta data fields are filled in correctly.
+            button won't activate before all meta data fields are filled in correctly.
           </div>
           <!-- Every mat tab has its own fragment_form call to keep each entity easily separated and organised -->
 
           <form [formGroup]="fragment_form">
             <mat-form-field class="input-form-full-width">
               <mat-label>Fragment name</mat-label>
-              <input matInput type="text" formControlName="name" />
-              <!--<input required matInput type="text" formControlName="name" />-->
+              <input required matInput type="text" formControlName="name" />
               <!--required> -->
               <mat-hint><b>Only</b> provide the number of the fragment</mat-hint>
-              <!--<mat-error *ngIf="fragment_form.get('name').errors?.['required']">You must enter a value.</mat-error>-->
+              <mat-error *ngIf="fragment_form.get('name').errors?.['required']">You must enter a value.</mat-error>
               <mat-error *ngIf="fragment_form.get('name').errors?.['pattern']"
                 >You entered disallowed characters.</mat-error
               >
@@ -221,11 +220,10 @@
 
             <mat-form-field class="input-form-full-width">
               <mat-label>Author name</mat-label>
-              <input matInput type="text" formControlName="author" />
-              <!--<input required matInput type="text" formControlName="author" />-->
+              <input required matInput type="text" formControlName="author" />
               <mat-hint>Provide the author of the fragment</mat-hint>
               <!-- i prefer the get function like this to prevent long getters-->
-              <!--<mat-error *ngIf="fragment_form.get('author').errors?.['required']">You must enter a value.</mat-error>-->
+              <mat-error *ngIf="fragment_form.get('author').errors?.['required']">You must enter a value.</mat-error>
               <mat-error *ngIf="fragment_form.get('author').errors?.['pattern']"
                 >You entered disallowed characters.</mat-error
               >
@@ -235,10 +233,9 @@
 
             <mat-form-field class="input-form-full-width">
               <mat-label>Title name</mat-label>
-              <!--<input required matInput type="text" formControlName="title" />-->
-              <input matInput type="text" formControlName="title" />
+              <input required matInput type="text" formControlName="title" />
               <mat-hint>Provide the name of the book</mat-hint>
-              <!--<mat-error *ngIf="fragment_form.get('title').errors?.['required']">You must enter a value.</mat-error>-->
+              <mat-error *ngIf="fragment_form.get('title').errors?.['required']">You must enter a value.</mat-error>
               <mat-error *ngIf="fragment_form.get('title').errors?.['pattern']"
                 >You entered disallowed characters.</mat-error
               >
@@ -248,10 +245,9 @@
 
             <mat-form-field class="input-form-full-width">
               <mat-label>Editor name</mat-label>
-              <!--<input required matInput type="text" formControlName="editor" />-->
-              <input matInput type="text" formControlName="editor" />
+              <input required matInput type="text" formControlName="editor" />
               <mat-hint>Provide the name of the editor</mat-hint>
-              <!--<mat-error *ngIf="fragment_form.get('editor').errors?.['required']">You must enter a value.</mat-error>-->
+              <mat-error *ngIf="fragment_form.get('editor').errors?.['required']">You must enter a value.</mat-error>
               <mat-error *ngIf="fragment_form.get('editor').errors?.['pattern']"
                 >You entered disallowed characters.</mat-error
               >
@@ -260,35 +256,12 @@
             <div class="div-padding-sm"></div>
 
             <mat-form-field appearance="fill">
-              <mat-select formControlName="status" ngDefaultControl>
-                <!--<mat-select required formControlName="status" ngDefaultControl>-->
+              <mat-select required formControlName="status" ngDefaultControl>
                 <mat-option value="Certum">Certum</mat-option>
                 <mat-option value="Incertum">Incertum</mat-option>
                 <mat-option value="Adesp.">Adespoton</mat-option>
               </mat-select>
               <mat-label>Line status</mat-label>
-            </mat-form-field>
-
-            <hr />
-            <mat-form-field appearance="fill">
-              <!--<mat-select required formControlName="document_type" ngDefaultControl>-->
-              <mat-select formControlName="document_type" ngDefaultControl>
-                <mat-option value="fragment">Fragment</mat-option>
-                <mat-option value="testimonium">Testimonium</mat-option>
-              </mat-select>
-              <mat-label>Document type</mat-label>
-            </mat-form-field>
-            <mat-form-field class="input-form-full-width">
-              <mat-label>Witness</mat-label>
-              <!--<input required matInput type="text" formControlName="witness" />-->
-              <input matInput type="text" formControlName="witness" />
-              <mat-hint>Provide the name of the witness</mat-hint>
-            </mat-form-field>
-            <mat-form-field class="input-form-full-width">
-              <mat-label>Text</mat-label>
-              <input matInput type="text" formControlName="text" />
-              <!--<input required matInput type="text" formControlName="text" />-->
-              <mat-hint>Provide the testimonium text</mat-hint>
             </mat-form-field>
 
             <div class="div-padding"></div>

--- a/Angular/src/app/dashboard/dashboard.component.html
+++ b/Angular/src/app/dashboard/dashboard.component.html
@@ -47,7 +47,7 @@
     <!-- Change fragment expansion panel -->
     <mat-expansion-panel
       *ngIf="this.auth_service.current_user_role === 'teacher' || this.auth_service.current_user_role === 'student'"
-      [expanded]="true">
+      [expanded]="false">
       <mat-expansion-panel-header>
         <mat-panel-title> Change fragment data </mat-panel-title>
         <mat-panel-description>
@@ -625,6 +625,18 @@
         </mat-tab>
         <!-- end of the Fragment lock tab -->
       </mat-tab-group>
+    </mat-expansion-panel>
+    <hr />
+    <!-- Change testimonia expansion panel -->
+    <mat-expansion-panel *ngIf="this.auth_service.current_user_role === 'teacher'" [expanded]="true">
+      <mat-expansion-panel-header>
+        <mat-panel-title> Change testimonia data </mat-panel-title>
+        <mat-panel-description>
+          Create, revise and delete testimonia
+          <mat-icon>local_library</mat-icon>
+        </mat-panel-description>
+      </mat-expansion-panel-header>
+      <app-testimonia-dashboard></app-testimonia-dashboard>
     </mat-expansion-panel>
     <hr />
     <!-- Change author/author+title introduction expansion panel -->

--- a/Angular/src/app/dashboard/dashboard.component.ts
+++ b/Angular/src/app/dashboard/dashboard.component.ts
@@ -41,16 +41,11 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   fragment_form = new FormGroup({
     _id: new FormControl(''),
-    //name: new FormControl('', [Validators.required, Validators.pattern('[0-9-_ ]*')]), // numbers and "-" and "_" allowed.
-    //author: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z ]*')]), // alpha characters allowed
-    //title: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z ]*')]), // alpha characters allowed
-    //editor: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z ]*')]), // alpha characters allowed
-    //name: new FormControl('', [Validators.pattern('[0-9-_ ]*')]), // numbers and "-" and "_" allowed.
-    name: new FormControl(''), // numbers and "-" and "_" allowed.
-    author: new FormControl('', [Validators.pattern('[a-zA-Z ]*')]), // alpha characters allowed
-    //title: new FormControl('', [Validators.pattern('[a-zA-Z ]*')]), // alpha characters allowed
-    title: new FormControl(''), // alpha characters allowed
-    editor: new FormControl('', [Validators.pattern('[a-zA-Z ]*')]), // alpha characters allowed
+    document_type: new FormControl('fragment'),
+    name: new FormControl('', [Validators.required, Validators.pattern('[0-9-_ ]*')]), // numbers and "-" and "_" allowed.
+    author: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z ]*')]), // alpha characters allowed
+    title: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z ]*')]), // alpha characters allowed
+    editor: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z ]*')]), // alpha characters allowed
     translation: new FormControl(''),
     differences: new FormControl(''),
     commentary: new FormControl(''),
@@ -68,9 +63,6 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
     status: new FormControl(''),
     published: new FormControl(''),
     lock: new FormControl(''),
-    document_type: new FormControl(''),
-    witness: new FormControl(''),
-    text: new FormControl(''),
   });
 
   // In this object all meta data is stored regarding the currently selected fragment
@@ -439,13 +431,13 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
         if (result) {
           const fragment = this.convert_fragment_form_to_Fragment(fragment_form);
           this.reset_fragment_form();
-          this.api.request_delete_fragment(
-            fragment.author,
-            fragment.title,
-            fragment.editor,
-            fragment.name,
-            environment.dashboard_id
-          );
+          this.api.request_delete_fragment({
+            document_type: 'fragment',
+            author: fragment.author,
+            title: fragment.title,
+            editor: fragment.editor,
+            name: fragment.name,
+          });
           this.fragment_selected = false;
         }
       });

--- a/Angular/src/app/dashboard/helper.service.spec.ts
+++ b/Angular/src/app/dashboard/helper.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HelperService } from './helper.service';
+
+describe('HelperService', () => {
+  let service: HelperService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(HelperService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/Angular/src/app/dashboard/helper.service.ts
+++ b/Angular/src/app/dashboard/helper.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HelperService {
+  constructor() {}
+}

--- a/Angular/src/app/dashboard/helper.service.ts
+++ b/Angular/src/app/dashboard/helper.service.ts
@@ -1,8 +1,45 @@
 import { Injectable } from '@angular/core';
+import { DialogService } from '@oscc/services/dialog.service';
+import { FormGroup, FormArray } from '@angular/forms';
 
 @Injectable({
   providedIn: 'root',
 })
 export class HelperService {
-  constructor() {}
+  constructor(protected dialog: DialogService) {}
+
+  /**
+   * This function requests a wysiwyg dialog to handle data updating to the fragment_form.
+   * It functions by providing the field of fragment_form which is to be updated by the editor.
+   * The dialog is called provided the config of the editor and the string to be edited. An edited string
+   * is returned by the dialog service
+   * @param FormGroup that is to be edited
+   * @param field representing the field of form which is to be send and updated
+   * @param type either formArray or formControl
+   * @param index (optional) when providing an formArray, to know which entry we are editing
+   * @author Ycreak
+   */
+  public request_wysiwyg_dialog(form: FormGroup, field: string, type: string, index = 0): FormGroup {
+    if (type == 'formArray') {
+      //For the context, retrieve the context text field from the fragment form and pass that to the dialog
+      //const form_array_field = this.fragment_form.value.context[index].text;
+      this.dialog.open_wysiwyg_dialog('hello there').subscribe((result) => {
+        if (result) {
+          // Result will only be provided when the user has acceped the changes
+          // Now update the correct field. This is done by getting the FormArray and patching the correct
+          // FormGroup within this array. This is to ensure dynamic updating on the frontend
+          const context_array = form.controls[field] as FormArray;
+          context_array.controls[index].patchValue({ ['text']: result });
+        }
+      });
+    } else {
+      // For formControls we can update by just getting their content strings
+      this.dialog.open_wysiwyg_dialog(form.value[field]).subscribe((result) => {
+        if (result) {
+          form.patchValue({ [field]: result });
+        }
+      });
+    }
+    return form;
+  }
 }

--- a/Angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.html
+++ b/Angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.html
@@ -6,7 +6,11 @@
     <mat-option
       *ngFor="let author of this.author_list"
       [value]="author.name"
-      (click)="this.request_testimonia_names(author.name)">
+      (click)="this.request_testimonia_names(author.name)"
+      (click)="this.selected_name = ''"
+      (click)="this.name_list = []"
+      (click)="this.reset_form()"
+      (click)="this.form.patchValue({ author: author.name })">
       {{ author.name }}
     </mat-option>
   </mat-select>
@@ -18,7 +22,8 @@
     <mat-option
       *ngFor="let name of this.name_list"
       [value]="name.name"
-      (click)="this.request_testimonium(this.selected_author, name.name)">
+      (click)="this.request_testimonium(this.selected_author, name.name)"
+      (click)="this.form.patchValue({ name: name.name })">
       {{ name.name }}
     </mat-option>
   </mat-select>
@@ -62,7 +67,7 @@
 
     <div class="alert alert-info" role="alert">
       To create a new testimonium, please provide all meta data and press the <b>Create testimonium</b> button. The
-      button wont activate before all meta data fields are filled in correctly.
+      button won't activate before all meta data fields are filled in correctly.
     </div>
     <!-- Every mat tab has its own form call to keep each entity easily separated and organised -->
 
@@ -109,4 +114,38 @@
     </form>
   </mat-tab>
   <!-- end of the Meta data tab -->
+  <mat-tab label="Testimonia Text"
+    ><br />
+    <form [formGroup]="form">
+      <mat-form-field class="input-form-full-width">
+        <mat-label><b>Testimonium text</b></mat-label>
+        <textarea matInput type="text" formControlName="text"></textarea>
+      </mat-form-field>
+      <button
+        mat-button
+        class="button-margin-extra"
+        (click)="this.form = this.helper.request_wysiwyg_dialog(this.form, 'text', 'formControl')">
+        Rich editor
+      </button>
+    </form>
+    <div class="div-padding-lg"></div>
+  </mat-tab>
+  <!-- end of the text tab -->
+  <mat-tab label="Testimonia Commentary"
+    ><br />
+    <form [formGroup]="form">
+      <mat-form-field class="input-form-full-width">
+        <mat-label><b>Testimonium translation</b></mat-label>
+        <textarea matInput type="text" formControlName="translation"></textarea>
+      </mat-form-field>
+      <button
+        mat-button
+        class="button-margin-extra"
+        (click)="this.form = this.helper.request_wysiwyg_dialog(this.form, 'translation', 'formControl')">
+        Rich editor
+      </button>
+    </form>
+    <div class="div-padding-lg"></div>
+  </mat-tab>
+  <!-- end of the content tab -->
 </mat-tab-group>

--- a/Angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.html
+++ b/Angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.html
@@ -1,0 +1,112 @@
+<!-- Selection of testimonium. All the clicks below are to make sure the form field stays in sync with
+    all types of unlogical user routes and inputs -->
+<mat-form-field>
+  <mat-label>Select author</mat-label>
+  <mat-select [(ngModel)]="this.selected_author" ngDefaultControl>
+    <mat-option
+      *ngFor="let author of this.author_list"
+      [value]="author.name"
+      (click)="this.request_testimonia_names(author.name)">
+      {{ author.name }}
+    </mat-option>
+  </mat-select>
+</mat-form-field>
+
+<mat-form-field>
+  <mat-label>Select name</mat-label>
+  <mat-select [(ngModel)]="this.selected_name" ngDefaultControl>
+    <mat-option
+      *ngFor="let name of this.name_list"
+      [value]="name.name"
+      (click)="this.request_testimonium(this.selected_author, name.name)">
+      {{ name.name }}
+    </mat-option>
+  </mat-select>
+</mat-form-field>
+
+<hr />
+
+<!--Buttons to submit testimonium data -->
+<button
+  mat-stroked-button
+  class="button-margin"
+  color="primary"
+  [disabled]="!form.valid"
+  (click)="request_create_testimonium(this.form.value)"
+  *ngIf="this.auth_service.current_user_role === 'teacher' || this.auth_service.current_user_role === 'student'">
+  Create testimonium
+</button>
+<button
+  mat-stroked-button
+  class="button-margin"
+  color="primary"
+  [disabled]="!form.valid"
+  (click)="request_revise_testimonium(this.form.value)"
+  *ngIf="this.auth_service.current_user_role === 'teacher' || this.auth_service.current_user_role === 'student'">
+  Save Changes
+</button>
+<button
+  mat-stroked-button
+  class="button-margin"
+  color="warn"
+  [disabled]="!testimonium_selected"
+  (click)="request_delete_testimonium(this.form.value)"
+  *ngIf="this.auth_service.current_user_role === 'teacher'">
+  Delete testimonium
+</button>
+
+<hr />
+<mat-tab-group>
+  <mat-tab label="Testimonia Meta Data"
+    ><br />
+
+    <div class="alert alert-info" role="alert">
+      To create a new testimonium, please provide all meta data and press the <b>Create testimonium</b> button. The
+      button wont activate before all meta data fields are filled in correctly.
+    </div>
+    <!-- Every mat tab has its own form call to keep each entity easily separated and organised -->
+
+    <form [formGroup]="form">
+      <mat-form-field class="input-form-full-width">
+        <mat-label>Testimonium name</mat-label>
+        <input required matInput type="text" formControlName="name" />
+        <mat-hint><b>Only</b> provide the number of the testimonium</mat-hint>
+        <mat-error *ngIf="form.get('name').errors?.['required']">You must enter a value.</mat-error>
+        <mat-error *ngIf="form.get('name').errors?.['pattern']">You entered disallowed characters.</mat-error>
+      </mat-form-field>
+
+      <div class="div-padding-sm"></div>
+
+      <mat-form-field class="input-form-full-width">
+        <mat-label>Author name</mat-label>
+        <input required matInput type="text" formControlName="author" />
+        <mat-hint>Provide the author mentioned in the testimonium</mat-hint>
+        <mat-error *ngIf="form.get('author').errors?.['required']">You must enter a value.</mat-error>
+        <mat-error *ngIf="form.get('author').errors?.['pattern']">You entered disallowed characters.</mat-error>
+      </mat-form-field>
+
+      <div class="div-padding-sm"></div>
+
+      <mat-form-field class="input-form-full-width">
+        <mat-label>Witness name</mat-label>
+        <input required matInput type="text" formControlName="witness" />
+        <mat-hint>Provide the name of the witness</mat-hint>
+        <mat-error *ngIf="form.get('witness').errors?.['required']">You must enter a value.</mat-error>
+        <mat-error *ngIf="form.get('witness').errors?.['pattern']">You entered disallowed characters.</mat-error>
+      </mat-form-field>
+
+      <div class="div-padding-sm"></div>
+
+      <mat-form-field class="input-form-full-width">
+        <mat-label>Title name</mat-label>
+        <input required matInput type="text" formControlName="title" />
+        <mat-hint>Provide the name of the witness' text</mat-hint>
+        <mat-error *ngIf="form.get('title').errors?.['required']">You must enter a value.</mat-error>
+        <mat-error *ngIf="form.get('title').errors?.['pattern']">You entered disallowed characters.</mat-error>
+      </mat-form-field>
+
+      <div class="div-padding-sm"></div>
+    </form>
+  </mat-tab>
+  <!-- end of the Meta data tab -->
+</mat-tab-group>

--- a/Angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.scss
+++ b/Angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.scss
@@ -1,0 +1,1 @@
+@import url("../dashboard.component.scss");

--- a/Angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.spec.ts
+++ b/Angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TestimoniaDashboardComponent } from './testimonia-dashboard.component';
+
+describe('TestimoniaDashboardComponent', () => {
+  let component: TestimoniaDashboardComponent;
+  let fixture: ComponentFixture<TestimoniaDashboardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestimoniaDashboardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestimoniaDashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.ts
+++ b/Angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.ts
@@ -1,0 +1,160 @@
+import { Component, OnInit, OnDestroy, AfterViewInit } from '@angular/core';
+import { FormControl, FormGroup, FormArray } from '@angular/forms';
+import { Validators } from '@angular/forms';
+import { Observable } from 'rxjs';
+
+// Component imports
+import { ApiService } from '@oscc/api.service';
+import { UtilityService } from '@oscc/utility.service';
+import { AuthService } from '@oscc/auth/auth.service';
+import { DialogService } from '@oscc/services/dialog.service';
+
+// Model imports
+import { Testimonium } from '@oscc/models/Testimonium';
+
+@Component({
+  selector: 'app-testimonia-dashboard',
+  templateUrl: './testimonia-dashboard.component.html',
+  styleUrls: ['./testimonia-dashboard.component.scss'],
+})
+export class TestimoniaDashboardComponent implements OnInit {
+  protected selected_author = '';
+  protected selected_name = '';
+
+  protected author_list = [];
+  protected name_list = [];
+
+  protected selected_testimonium: Testimonium;
+
+  form = new FormGroup({
+    _id: new FormControl(''),
+    document_type: new FormControl(''),
+    name: new FormControl('', [Validators.required, Validators.pattern('[0-9-_ ]*')]), // numbers and "-" and "_" allowed.
+    author: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z ]*')]), // alpha characters allowed
+    witness: new FormControl(''),
+    title: new FormControl(''),
+    text: new FormControl(''),
+
+    translation: new FormControl(''),
+    differences: new FormControl(''),
+    commentary: new FormControl(''),
+    apparatus: new FormControl(''),
+    metrical_analysis: new FormControl(''),
+    reconstruction: new FormControl(''),
+    published: new FormControl(''),
+    lock: new FormControl(''),
+  });
+
+  constructor(
+    protected api: ApiService,
+    protected utility: UtilityService,
+    protected dialog: DialogService,
+    protected auth_service: AuthService
+  ) {}
+
+  ngOnInit(): void {
+    this.api.get_authors({ document_type: 'testimonium' }).subscribe((authors) => {
+      this.author_list = authors;
+    });
+  }
+
+  protected request_testimonia_names(author: string): void {
+    this.api.get_names({ document_type: 'testimonium', author: author }).subscribe((names) => {
+      this.name_list = names;
+    });
+  }
+
+  protected request_testimonium(author: string, name: string): void {
+    this.api.get_documents({ document_type: 'testimonium', author: author, name: name }).subscribe((documents) => {
+      this.selected_testimonium = documents[0];
+    });
+  }
+
+  /**
+   * This function requests the api to revise the fragment given the fragment_form.
+   * @param fragment_form which represents a Fragment, edited by the user in the dashboard
+   * @author Ycreak
+   */
+  protected request_revise_testimonium(form: any): void {
+    // If the fragment is locked and the user is not a teacher, we will not allow this operation.
+    if (form.value.lock == 'locked' && this.auth_service.current_user_role != 'teacher') {
+      this.utility.open_snackbar('This fragment is locked.');
+    } else {
+      const item_string = form.author + ', ' + form.witness + ', ' + form.title + ': ' + form.name;
+      this.dialog
+        .open_confirmation_dialog('Are you sure you want to SAVE CHANGES to this fragment?', item_string)
+        .subscribe((result) => {
+          if (result) {
+            this.api.request_revise_fragment(form);
+            this.reset_form();
+          }
+        });
+    }
+  }
+
+  /**
+   * Given the fragment_form which represents a Fragment, this function requests the api to create a
+   * new fragment.
+   * @param fragment_form which represents a Fragment, edited by the user in the dashboard
+   * @author Ycreak
+   */
+  protected request_create_testimonium(form: any): void {
+    const item_string = form.value.author + ', ' + form.value.title + ', ' + form.value.editor + ': ' + form.value.name;
+
+    this.dialog
+      .open_confirmation_dialog('Are you sure you want to CREATE this fragment?', item_string)
+      .subscribe((result) => {
+        if (result) {
+          const fragment = this.convert_form_to_Fragment(fragment_form);
+          this.api.request_create_fragment(fragment, environment.dashboard_id);
+          this.fragment_selected = true;
+          this.reset_form();
+          // It might be possible we have created a new author, title or editor. Retrieve the lists again
+          // TODO: retrieve author-title-editor blob
+        }
+      });
+  }
+
+  /**
+   * Given the fragment_form which represents a Fragment, this function requests the api to delete the
+   * selected fragment. This is done via its id.
+   * @param fragment_form which represents a Fragment, edited by the user in the dashboard
+   * @author Ycreak
+   */
+  protected request_delete_testimonium(fragment_form: FormGroup): void {
+    const item_string =
+      fragment_form.value.author +
+      ', ' +
+      fragment_form.value.title +
+      ', ' +
+      fragment_form.value.editor +
+      ': ' +
+      fragment_form.value.name;
+
+    //this.dialog
+    //.open_confirmation_dialog('Are you sure you want to DELETE this fragment?', item_string)
+    //.subscribe((result) => {
+    //if (result) {
+    //const fragment = this.convert_fragment_form_to_Fragment(fragment_form);
+    //this.reset_fragment_form();
+    //this.api.request_delete_fragment(
+    //fragment.author,
+    //fragment.title,
+    //fragment.editor,
+    //fragment.name,
+    //environment.dashboard_id
+    //);
+    //this.fragment_selected = false;
+    //}
+    //});
+  }
+
+  /**
+   * Function to reset the fragment form
+   * @author Ycreak
+   */
+  protected reset_form(): void {
+    // First, remove all data from the form
+    this.form.reset();
+  }
+}

--- a/Angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.ts
+++ b/Angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.ts
@@ -1,13 +1,13 @@
-import { Component, OnInit, OnDestroy, AfterViewInit } from '@angular/core';
-import { FormControl, FormGroup, FormArray } from '@angular/forms';
+import { Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
 import { Validators } from '@angular/forms';
-import { Observable } from 'rxjs';
 
 // Component imports
 import { ApiService } from '@oscc/api.service';
 import { UtilityService } from '@oscc/utility.service';
 import { AuthService } from '@oscc/auth/auth.service';
 import { DialogService } from '@oscc/services/dialog.service';
+import { HelperService } from '@oscc/dashboard/helper.service';
 
 // Model imports
 import { Testimonium } from '@oscc/models/Testimonium';
@@ -21,6 +21,7 @@ export class TestimoniaDashboardComponent implements OnInit {
   protected selected_author = '';
   protected selected_name = '';
 
+  // Used in the drop down menus
   protected author_list = [];
   protected name_list = [];
 
@@ -28,7 +29,7 @@ export class TestimoniaDashboardComponent implements OnInit {
 
   form = new FormGroup({
     _id: new FormControl(''),
-    document_type: new FormControl(''),
+    document_type: new FormControl('testimonium'),
     name: new FormControl('', [Validators.required, Validators.pattern('[0-9-_ ]*')]), // numbers and "-" and "_" allowed.
     author: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z ]*')]), // alpha characters allowed
     witness: new FormControl(''),
@@ -49,7 +50,8 @@ export class TestimoniaDashboardComponent implements OnInit {
     protected api: ApiService,
     protected utility: UtilityService,
     protected dialog: DialogService,
-    protected auth_service: AuthService
+    protected auth_service: AuthService,
+    protected helper: HelperService
   ) {}
 
   ngOnInit(): void {
@@ -71,8 +73,8 @@ export class TestimoniaDashboardComponent implements OnInit {
   }
 
   /**
-   * This function requests the api to revise the fragment given the fragment_form.
-   * @param fragment_form which represents a Fragment, edited by the user in the dashboard
+   * This function requests the api to revise the testimonium given the form.
+   * @param form which represents a testimonium, edited by the user in the dashboard
    * @author Ycreak
    */
   protected request_revise_testimonium(form: any): void {
@@ -93,60 +95,43 @@ export class TestimoniaDashboardComponent implements OnInit {
   }
 
   /**
-   * Given the fragment_form which represents a Fragment, this function requests the api to create a
-   * new fragment.
-   * @param fragment_form which represents a Fragment, edited by the user in the dashboard
+   * Given the form which represents a Testimonium, this function requests the api to create a
+   * new testimonium.
+   * @param object which represents a testimonium, edited by the user in the dashboard
    * @author Ycreak
    */
   protected request_create_testimonium(form: any): void {
-    const item_string = form.value.author + ', ' + form.value.title + ', ' + form.value.editor + ': ' + form.value.name;
-
+    const item_string = form.author + ', ' + form.witness + ', ' + form.title + ': ' + form.name;
     this.dialog
-      .open_confirmation_dialog('Are you sure you want to CREATE this fragment?', item_string)
+      .open_confirmation_dialog('Are you sure you want to CREATE this testimonium?', item_string)
       .subscribe((result) => {
         if (result) {
-          const fragment = this.convert_form_to_Fragment(fragment_form);
-          this.api.request_create_fragment(fragment, environment.dashboard_id);
-          this.fragment_selected = true;
+          this.api.request_create_fragment(form);
           this.reset_form();
-          // It might be possible we have created a new author, title or editor. Retrieve the lists again
-          // TODO: retrieve author-title-editor blob
         }
       });
   }
 
   /**
-   * Given the fragment_form which represents a Fragment, this function requests the api to delete the
-   * selected fragment. This is done via its id.
+   * Given the form which represents a testimonium, this function requests the api to delete the
+   * selected testimonium. This is done via its id.
    * @param fragment_form which represents a Fragment, edited by the user in the dashboard
    * @author Ycreak
    */
-  protected request_delete_testimonium(fragment_form: FormGroup): void {
-    const item_string =
-      fragment_form.value.author +
-      ', ' +
-      fragment_form.value.title +
-      ', ' +
-      fragment_form.value.editor +
-      ': ' +
-      fragment_form.value.name;
-
-    //this.dialog
-    //.open_confirmation_dialog('Are you sure you want to DELETE this fragment?', item_string)
-    //.subscribe((result) => {
-    //if (result) {
-    //const fragment = this.convert_fragment_form_to_Fragment(fragment_form);
-    //this.reset_fragment_form();
-    //this.api.request_delete_fragment(
-    //fragment.author,
-    //fragment.title,
-    //fragment.editor,
-    //fragment.name,
-    //environment.dashboard_id
-    //);
-    //this.fragment_selected = false;
-    //}
-    //});
+  protected request_delete_testimonium(form: any): void {
+    const item_string = form.author + ', ' + form.witness + ', ' + form.title + ': ' + form.name;
+    this.dialog
+      .open_confirmation_dialog('Are you sure you want to DELETE this testimonium?', item_string)
+      .subscribe((result) => {
+        if (result) {
+          this.reset_form();
+          this.api.request_delete_fragment({
+            document_type: 'testimonium',
+            author: form.author,
+            name: form.name,
+          });
+        }
+      });
   }
 
   /**

--- a/Server/endpoints/fragment.py
+++ b/Server/endpoints/fragment.py
@@ -307,15 +307,28 @@ def update_fragment():
     return make_response("Revised", 200)
 
 def delete_fragment():
-    try:
-        author = request.get_json()[FragmentField.AUTHOR]
-        title = request.get_json()[FragmentField.TITLE]
-        editor = request.get_json()[FragmentField.EDITOR]
-        name = request.get_json()[FragmentField.NAME]
-    except KeyError as e:
-        logging.error(e)
-        return make_response("Unprocessable entity", 422)
-    fragment = fragments.delete(Fragment(author=author, title=title, editor=editor, name=name))
+    document_type = request.get_json()[FragmentField.DOCUMENT_TYPE]
+
+    if document_type == 'testimonium':
+        try:
+            author = request.get_json()[FragmentField.AUTHOR]
+            name = request.get_json()[FragmentField.NAME]
+        except KeyError as e:
+            logging.error(e)
+            return make_response("Unprocessable entity", 422)
+        fragment = fragments.delete(Fragment(author=author, name=name, document_type=document_type))
+
+    elif document_type == 'fragment':
+        try:
+            author = request.get_json()[FragmentField.AUTHOR]
+            title = request.get_json()[FragmentField.TITLE]
+            editor = request.get_json()[FragmentField.EDITOR]
+            name = request.get_json()[FragmentField.NAME]
+        except KeyError as e:
+            logging.error(e)
+            return make_response("Unprocessable entity", 422)
+        fragment = fragments.delete(Fragment(author=author, title=title, editor=editor, name=name, document_type=document_type))
+
 
     if fragment:
         return make_response("OK", 200)

--- a/Server/endpoints/fragment.py
+++ b/Server/endpoints/fragment.py
@@ -29,6 +29,7 @@ def get_author():
     title = None
     editor = None
     name = None
+    document_type = None
     try:
         if FragmentField.AUTHOR in request.get_json():
             author = request.get_json()[FragmentField.AUTHOR]
@@ -38,10 +39,12 @@ def get_author():
             editor = request.get_json()[FragmentField.EDITOR]
         if FragmentField.NAME in request.get_json():
             name = request.get_json()[FragmentField.NAME]
+        if FragmentField.DOCUMENT_TYPE in request.get_json():
+            document_type = request.get_json()[FragmentField.DOCUMENT_TYPE]
     except KeyError as e:
         logging.error(e)
         return make_response("Unprocessable entity", 422)
-    fragment_lst = fragments.filter(Fragment(author=author, title=title, editor=editor, name=name), sorted=True)
+    fragment_lst = fragments.filter(Fragment(author=author, title=title, editor=editor, name=name, document_type=document_type), sorted=True)
     if not fragment_lst:
         return make_response("Not found", 401)
     return jsonify(sorted(set([frag.author for frag in fragment_lst]))), 200
@@ -95,6 +98,8 @@ def get_name():
     title = None
     editor = None
     name = None
+    document_type = None
+
     try:
         if FragmentField.AUTHOR in request.get_json():
             author = request.get_json()[FragmentField.AUTHOR]
@@ -104,10 +109,12 @@ def get_name():
             editor = request.get_json()[FragmentField.EDITOR]
         if FragmentField.NAME in request.get_json():
             name = request.get_json()[FragmentField.NAME]
+        if FragmentField.DOCUMENT_TYPE in request.get_json():
+            document_type = request.get_json()[FragmentField.DOCUMENT_TYPE]
     except KeyError as e:
         logging.error(e)
         return make_response("Unprocessable entity", 422)
-    fragment_lst = fragments.filter(Fragment(author=author, title=title, editor=editor, name=name), sorted=True)
+    fragment_lst = fragments.filter(Fragment(author=author, title=title, editor=editor, name=name, document_type=document_type), sorted=True)
     if not fragment_lst:
         return make_response("Not found", 401)
     return jsonify(list(set([frag.name for frag in fragment_lst]))), 200


### PR DESCRIPTION
This PR allows testimonia to be created/revised/deleted via the dashboard. It is a bit drafty because Flask isnt ready yet, but it should work once it is.

**Functional tests**

- [x] Quickly skim the code for weird things. Shouldn't be any problems, as it was copy paste work from the dashboard component.