### PR TITLE
Translations now stay open with toggle (thx seb)

### DIFF
--- a/Angular/src/app/app.module.ts
+++ b/Angular/src/app/app.module.ts
@@ -94,6 +94,7 @@ import { TestimoniaComponent } from './columns/testimonia/testimonia.component';
 import { FragmentComponent } from './columns/fragment/fragment.component';
 import { OnCopyDirective } from './directives/on-copy.directive';
 import { TestimoniaDashboardComponent } from './dashboard/testimonia-dashboard/testimonia-dashboard.component';
+import { TranslationComponent } from './commentary/translation/translation.component';
 
 // Routes to take. Disallows Path Traversal.
 const appRoutes: Routes = [
@@ -131,6 +132,7 @@ const appRoutes: Routes = [
     FragmentComponent,
     OnCopyDirective,
     TestimoniaDashboardComponent,
+    TranslationComponent,
   ],
   imports: [
     BrowserModule,

--- a/Angular/src/app/commentary/commentary.component.html
+++ b/Angular/src/app/commentary/commentary.component.html
@@ -16,26 +16,9 @@
         </div>
     </div> -->
 
-<!-- Template for commentary column -->
+<!-- Template for commentary column: TODO: take this out of this template -->
 <ng-template #commentary_column_template let-given_fragment="given_fragment">
-  <ng-container *ngIf="this.translated; else fragments_not_translated">
-    <ng-container
-      *ngTemplateOutlet="
-        show_fragment_content_orig_text;
-        context: { current_document_content: given_fragment.lines, title: 'Original text' }
-      ">
-    </ng-container>
-  </ng-container>
-  <!-- Show the translation of the fragment -->
-
-  <ng-template #fragments_not_translated>
-    <ng-container
-      *ngTemplateOutlet="
-        show_fragment_content;
-        context: { current_document_content: given_fragment.translation, title: 'Fragment Translation' }
-      ">
-    </ng-container>
-  </ng-template>
+  <app-translation [commentary]="given_fragment" [translated]="this.translated"></app-translation>
   <!-- Show the fragment's original text -->
 
   <ng-container

--- a/Angular/src/app/commentary/translation/translation.component.html
+++ b/Angular/src/app/commentary/translation/translation.component.html
@@ -1,0 +1,13 @@
+<mat-expansion-panel>
+  <mat-expansion-panel-header>
+    <mat-panel-title>
+      <b>{{ this.expansion_panel_title }}</b>
+    </mat-panel-title>
+  </mat-expansion-panel-header>
+  <div class="mat-expansion-panel-content">
+    <div class="mat-expansion-panel-body">
+      <app-expandable-text [content]="this.translation"></app-expandable-text>
+    </div>
+  </div>
+</mat-expansion-panel>
+<hr />

--- a/Angular/src/app/commentary/translation/translation.component.spec.ts
+++ b/Angular/src/app/commentary/translation/translation.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TranslationComponent } from './translation.component';
+
+describe('TranslationComponent', () => {
+  let component: TranslationComponent;
+  let fixture: ComponentFixture<TranslationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TranslationComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TranslationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Angular/src/app/commentary/translation/translation.component.ts
+++ b/Angular/src/app/commentary/translation/translation.component.ts
@@ -1,0 +1,46 @@
+/**
+ * The translation component of the commentary differs because it can accept translations and original text. The problem is that
+ * the original text might be represented by lines instead of by a simple string. This component handles this possibility.
+ */
+
+import { Component, Input, SimpleChanges, OnChanges } from '@angular/core';
+import { Commentary } from '@oscc/models/Commentary';
+import { Line } from '@oscc/models/Line';
+
+@Component({
+  selector: 'app-translation',
+  templateUrl: './translation.component.html',
+  styleUrls: ['./translation.component.scss'],
+})
+export class TranslationComponent implements OnChanges {
+  @Input() commentary: Commentary;
+  @Input() translated: boolean;
+
+  protected translation: string;
+  protected expansion_panel_title: string;
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.translated) {
+      this.process_translation();
+    }
+  }
+
+  /**
+   * Sets the correct title and translation given the translated flag.
+   * @author Ycreak
+   */
+  private process_translation(): void {
+    if (this.translated) {
+      this.expansion_panel_title = 'Original text';
+      this.translation = '';
+      //TODO: this does not add HTML like the <10> flag. This function is part of the Fragment model,
+      // not the commentary model. We will probably need to put these functions in a helper service.
+      this.commentary.lines.forEach((line: Line) => {
+        this.translation += `<p>${line.line_number}: ${line.text}</p>`;
+      });
+    } else {
+      this.expansion_panel_title = 'Fragment translation';
+      this.translation = this.commentary.translation;
+    }
+  }
+}


### PR DESCRIPTION
I move the translation expansion panel into its own component. It will take the translated flag and show the original text or translation accordingly in the same expansion panel. Saves a lot of weird checks. Now the panel also stays open when moving between translated/non translated columns. Also, clicking the same fragment again after translating the column correctly changes the expansion panel.