### PR TITLE
Linked commentary can now open original edition

### DIFF
--- a/Angular/src/app/columns/columns.component.ts
+++ b/Angular/src/app/columns/columns.component.ts
@@ -1,6 +1,6 @@
 // Library imports
 import { Component, OnInit, ViewEncapsulation, ViewChild } from '@angular/core';
-import { Output, EventEmitter } from '@angular/core';
+import { Output, EventEmitter, Input, OnChanges } from '@angular/core';
 import { trigger, transition, style, animate } from '@angular/animations';
 import { MatDialog } from '@angular/material/dialog';
 //import { environment } from '@src/environments/environment';
@@ -35,7 +35,8 @@ import { MatMenuTrigger } from '@angular/material/menu';
     ]),
   ],
 })
-export class ColumnsComponent implements OnInit {
+export class ColumnsComponent implements OnInit, OnChanges {
+  @Input() requested_column: any;
   @Output() clicked_document = new EventEmitter<any>();
 
   public current_document: any; // Variable to store the clicked fragment and its data
@@ -69,6 +70,22 @@ export class ColumnsComponent implements OnInit {
       );
     }
     this.request_documents(1, { document_type: 'fragment', author: 'Ennius', title: 'Thyestes', editor: 'Ribbeck' });
+  }
+
+  ngOnChanges() {
+    // If a new column is requested, we will handle the request here
+    if (this.requested_column) {
+      const column_id = this.column_handler.add_new_column('fragment');
+      const filter = {
+        author: this.requested_column.author,
+        title: this.requested_column.title,
+        editor: this.requested_column.editor,
+      };
+      this.api.get_documents(filter).subscribe((documents) => {
+        documents = this.format_incoming_documents(documents);
+        this.column_handler.add_documents_to_column(column_id, documents);
+      });
+    }
   }
 
   /**

--- a/Angular/src/app/commentary/commentary.component.html
+++ b/Angular/src/app/commentary/commentary.component.html
@@ -96,8 +96,10 @@
 <div *ngFor="let linked_fragment of this.linked_commentaries">
   <div *ngIf="linked_fragment.commentary.has_content()">
     <h6>
-      Commentary from {{ linked_fragment.author }}, {{ linked_fragment.title }}, {{ linked_fragment.editor }},
-      {{ linked_fragment.name }}
+      <a class="a-void" (click)="this.request_column.emit(linked_fragment)">
+        Commentary from {{ linked_fragment.author }}, {{ linked_fragment.title }}, {{ linked_fragment.editor }},
+        {{ linked_fragment.name }}
+      </a>
     </h6>
     <ng-container
       [ngTemplateOutlet]="commentary_column_template"

--- a/Angular/src/app/commentary/commentary.component.ts
+++ b/Angular/src/app/commentary/commentary.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, SimpleChanges, OnChanges } from '@angular/core';
+import { Output, EventEmitter } from '@angular/core';
 import { ApiService } from '@oscc/api.service';
 import { StringFormatterService } from '@oscc/services/string-formatter.service';
 
@@ -19,6 +20,8 @@ export class CommentaryComponent implements OnChanges {
   @Input() commentary: Commentary;
   @Input() document: any;
   @Input() translated: boolean;
+
+  @Output() request_column = new EventEmitter<any>();
 
   protected document_clicked = false;
   protected translation_orig_text_expanded = false;

--- a/Angular/src/app/overview/overview.component.html
+++ b/Angular/src/app/overview/overview.component.html
@@ -78,7 +78,8 @@
 <div>
   <mat-drawer-container class="drawer-container" autosize>
     <div class="overview-sidenav-content">
-      <app-columns (clicked_document)="this.clicked_document = $event"> </app-columns>
+      <app-columns [requested_column]="this.requested_column" (clicked_document)="this.clicked_document = $event">
+      </app-columns>
     </div>
 
     <hr />
@@ -114,7 +115,8 @@
             #commentary
             [document]="this.clicked_document"
             [commentary]="this.clicked_document.commentary"
-            [translated]="this.clicked_document.translated">
+            [translated]="this.clicked_document.translated"
+            (request_column)="this.requested_column = $event">
           </app-commentary>
         </ng-template>
       </div>

--- a/Angular/src/app/overview/overview.component.ts
+++ b/Angular/src/app/overview/overview.component.ts
@@ -37,6 +37,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
   protected playground_enabled = true;
 
   protected clicked_document: Fragment;
+  protected requested_column: any;
 
   constructor(
     protected api: ApiService,


### PR DESCRIPTION
This PR allows the user to open the column of the linked edition when the commentary of a linked edition is requested.

Closes #84. 