### PR TITLE
Sajvanwijk/issue185

### DIFF
--- a/Angular/.prettierrc.json
+++ b/Angular/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "printWidth": 120,
   "endOfLine": "lf",
-  "bracketSameLine": true
+  "bracketSameLine": true,
+  "trailingComma": "es5"
 }

--- a/Angular/src/app/columns/columns.component.html
+++ b/Angular/src/app/columns/columns.component.html
@@ -138,7 +138,10 @@
       <div
         class="fragment-box"
         (click)="handle_document_click(fragment, given_column)"
-        (contextmenu)="handle_document_click(fragment, given_column); onRightClick($event, this.current_fragment)"
+        (contextmenu)="
+          handle_document_click(fragment, given_column);
+          onRightClick($event, this.current_document, this.current_column)
+        "
         cdkDrag
         [cdkDragDisabled]="this.settings.fragments.dragging_disabled"
         (cdkDragDropped)="this.column_handler.track_edited_columns($event)"
@@ -163,8 +166,10 @@
 <!-- Context menu for right click actions on fragments -->
 <mat-menu #rightMenu="matMenu">
   <ng-template matMenuContent let-item="item">
-    <button (click)="this.copy_document_content(this.current_document)" mat-menu-item>Copy text</button>
-    <button (click)="this.show_linked_documents(this.current_document)" mat-menu-item>Linked documents</button>
+    <button (click)="this.copy_document_content(matMenuTrigger.menuData.document)" mat-menu-item>Copy text</button>
+    <button (click)="this.show_linked_documents(matMenuTrigger.menuData.document)" mat-menu-item>
+      Linked documents
+    </button>
   </ng-template>
 </mat-menu>
 

--- a/Angular/src/app/columns/columns.component.html
+++ b/Angular/src/app/columns/columns.component.html
@@ -170,6 +170,7 @@
     <button (click)="this.show_linked_documents(matMenuTrigger.menuData.document)" mat-menu-item>
       Linked documents
     </button>
+    <button (click)="this.close_column(matMenuTrigger.menuData.column)" mat-menu-item>Close column</button>
   </ng-template>
 </mat-menu>
 

--- a/Angular/src/app/columns/columns.component.html
+++ b/Angular/src/app/columns/columns.component.html
@@ -170,7 +170,6 @@
     <button (click)="this.show_linked_documents(matMenuTrigger.menuData.document)" mat-menu-item>
       Linked documents
     </button>
-    <button (click)="this.close_column(matMenuTrigger.menuData.column)" mat-menu-item>Close column</button>
   </ng-template>
 </mat-menu>
 

--- a/Angular/src/app/columns/columns.component.ts
+++ b/Angular/src/app/columns/columns.component.ts
@@ -337,6 +337,10 @@ export class ColumnsComponent implements OnInit, OnChanges {
     this.matMenuTrigger.openMenu();
   }
 
+  protected close_column(column: Column): void {
+    this.column_handler.close_column(column.column_id);
+  }
+
   /**
    * Given the fragment, this function checks whether its linked fragments appear in the
    * other opened columns. If so, the columns are scrolled to put the linked fragment in view

--- a/Angular/src/app/columns/columns.component.ts
+++ b/Angular/src/app/columns/columns.component.ts
@@ -337,10 +337,6 @@ export class ColumnsComponent implements OnInit, OnChanges {
     this.matMenuTrigger.openMenu();
   }
 
-  protected close_column(column: Column): void {
-    this.column_handler.close_column(column.column_id);
-  }
-
   /**
    * Given the fragment, this function checks whether its linked fragments appear in the
    * other opened columns. If so, the columns are scrolled to put the linked fragment in view

--- a/Angular/src/app/columns/columns.component.ts
+++ b/Angular/src/app/columns/columns.component.ts
@@ -52,7 +52,7 @@ export class ColumnsComponent implements OnInit, OnChanges {
     protected column_handler: ColumnHandlerService,
     protected settings: SettingsService,
     private bib_helper: BibliographyHelperService,
-    private matdialog: MatDialog
+    private matdialog: MatDialog,
   ) {}
 
   ngOnInit(): void {
@@ -69,7 +69,7 @@ export class ColumnsComponent implements OnInit, OnChanges {
           author: 'Ennius',
           title: 'Thyestes',
           editor: 'TRF',
-        })
+        }),
       );
     }
     this.current_column = this.column_handler.columns[0];
@@ -154,12 +154,13 @@ export class ColumnsComponent implements OnInit, OnChanges {
     //this.document_clicked2.emit(document);
     this.document_clicked = true;
     this.current_document = document;
+    this.current_column = column;
 
     // The next part handles the colouring of clicked and referenced documents.
     // First, restore all documents to their original black colour when a new document is clicked
     for (const index in this.column_handler.columns) {
       this.column_handler.columns[index] = this.column_handler.colour_documents_black(
-        this.column_handler.columns[index]
+        this.column_handler.columns[index],
       );
     }
     // Second, colour the clicked document
@@ -320,7 +321,7 @@ export class ColumnsComponent implements OnInit, OnChanges {
   // reference to the MatMenuTrigger in the DOM
   @ViewChild(MatMenuTrigger, { static: true }) matMenuTrigger: MatMenuTrigger;
 
-  protected onRightClick(event: MouseEvent, item: any) {
+  protected onRightClick(event: MouseEvent, document: any, column: Column) {
     // preventDefault avoids to show the visualization of the right-click menu of the browser
     event.preventDefault();
 
@@ -330,7 +331,7 @@ export class ColumnsComponent implements OnInit, OnChanges {
 
     // we open the menu
     // we pass to the menu the information about our object
-    this.matMenuTrigger.menuData = { item: item };
+    this.matMenuTrigger.menuData = { document, column };
 
     // we open the menu
     this.matMenuTrigger.openMenu();

--- a/Angular/src/app/columns/columns.component.ts
+++ b/Angular/src/app/columns/columns.component.ts
@@ -330,7 +330,7 @@ export class ColumnsComponent implements OnInit, OnChanges {
     this.menuTopLeftPosition.y = event.clientY + 'px';
 
     // we open the menu
-    // we pass to the menu the information about our object
+    // we pass to the menu the information about our document and column
     this.matMenuTrigger.menuData = { document, column };
 
     // we open the menu

--- a/Angular/src/app/columns/columns.component.ts
+++ b/Angular/src/app/columns/columns.component.ts
@@ -52,7 +52,7 @@ export class ColumnsComponent implements OnInit, OnChanges {
     protected column_handler: ColumnHandlerService,
     protected settings: SettingsService,
     private bib_helper: BibliographyHelperService,
-    private matdialog: MatDialog,
+    private matdialog: MatDialog
   ) {}
 
   ngOnInit(): void {
@@ -69,7 +69,7 @@ export class ColumnsComponent implements OnInit, OnChanges {
           author: 'Ennius',
           title: 'Thyestes',
           editor: 'TRF',
-        }),
+        })
       );
     }
     this.current_column = this.column_handler.columns[0];
@@ -160,7 +160,7 @@ export class ColumnsComponent implements OnInit, OnChanges {
     // First, restore all documents to their original black colour when a new document is clicked
     for (const index in this.column_handler.columns) {
       this.column_handler.columns[index] = this.column_handler.colour_documents_black(
-        this.column_handler.columns[index],
+        this.column_handler.columns[index]
       );
     }
     // Second, colour the clicked document


### PR DESCRIPTION
Closes #185 

The data can now be accessed through matMenuTrigger.menuData.document or matMenuTrigger.menuData.column on the columns component. Check out the commit called 'Close column button for testing'. There i've added a close column button in the context menu to demonstrate that the right click menu now knows the current column.