### PR TITLE
Commentary overhaul

### DIFF
--- a/Angular/src/app/columns/columns.component.ts
+++ b/Angular/src/app/columns/columns.component.ts
@@ -64,7 +64,7 @@ export class ColumnsComponent implements OnInit, OnChanges {
       );
     }
     this.current_column = this.column_handler.columns[0];
-    //this.request_documents(1, { document_type: 'fragment', author: 'Ennius', title: 'Thyestes', editor: 'Ribbeck' });
+    this.request_documents(1, { document_type: 'fragment', author: 'Ennius', title: 'Thyestes', editor: 'TRF' });
   }
 
   ngOnChanges() {

--- a/Angular/src/app/commentary/commentary.component.html
+++ b/Angular/src/app/commentary/commentary.component.html
@@ -12,27 +12,27 @@
 
 <ng-template #commentary_column_template let-commentary="given_commentary">
   <!-- Show the fragment's translation or original text -->
-  <ng-container *ngIf="commentary.translation">
-    <app-translation [commentary]="commentary" [translated]="this.translated"></app-translation>
+  <ng-container *ngIf="commentary.fields.translation">
+    <app-translation [document]="document" [translated]="this.translated"></app-translation>
     <hr
   /></ng-container>
 
-  <ng-container *ngIf="commentary.apparatus">
+  <ng-container *ngIf="commentary.fields.apparatus">
     <app-general-commentary-field
-      [content]="commentary.apparatus"
+      [content]="commentary.fields.apparatus"
       [title]="'Apparatus Criticus'"></app-general-commentary-field>
     <hr
   /></ng-container>
 
-  <ng-container *ngIf="commentary.differences">
+  <ng-container *ngIf="commentary.fields.differences">
     <app-general-commentary-field
-      [content]="commentary.differences"
+      [content]="commentary.fields.differences"
       [title]="'Editorial Differences'"></app-general-commentary-field>
     <hr
   /></ng-container>
 
-  <ng-container *ngIf="!this.utility.is_empty_array(commentary.context)">
-    <div *ngFor="let current_context of commentary.context">
+  <ng-container *ngIf="!this.utility.is_empty_array(commentary.fields.context)">
+    <div *ngFor="let current_context of commentary.fields.context">
       <mat-expansion-panel>
         <mat-expansion-panel-header class="citation-context-mat-exp-header">
           <mat-panel-title>
@@ -53,23 +53,23 @@
     <hr />
   </ng-container>
 
-  <ng-container *ngIf="commentary.commentary">
+  <ng-container *ngIf="commentary.fields.commentary">
     <app-general-commentary-field
-      [content]="commentary.commentary"
+      [content]="commentary.fields.commentary"
       [title]="'Fragment Commentary'"></app-general-commentary-field>
     <hr
   /></ng-container>
 
-  <ng-container *ngIf="commentary.metrical_analysis">
+  <ng-container *ngIf="commentary.fields.metrical_analysis">
     <app-general-commentary-field
-      [content]="commentary.metrical_analysis"
+      [content]="commentary.fields.metrical_analysis"
       [title]="'Metrical Analysis'"></app-general-commentary-field>
     <hr
   /></ng-container>
 
-  <ng-container *ngIf="commentary.reconstuction">
+  <ng-container *ngIf="commentary.fields.reconstuction">
     <app-general-commentary-field
-      [content]="commentary.reconstruction"
+      [content]="commentary.fields.reconstruction"
       [title]="'Fragment Reconstruction'"></app-general-commentary-field>
     <hr
   /></ng-container>

--- a/Angular/src/app/commentary/translation/translation.component.ts
+++ b/Angular/src/app/commentary/translation/translation.component.ts
@@ -3,7 +3,7 @@
  * the original text might be represented by lines instead of by a simple string. This component handles this possibility.
  */
 
-import { Component, Input, SimpleChanges, OnChanges } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { Commentary } from '@oscc/models/Commentary';
 import { Line } from '@oscc/models/Line';
 
@@ -13,16 +13,17 @@ import { Line } from '@oscc/models/Line';
   styleUrls: ['./translation.component.scss'],
 })
 export class TranslationComponent implements OnChanges {
-  @Input() commentary: Commentary;
+  @Input() document: any;
   @Input() translated: boolean;
+
+  protected commentary: Commentary;
 
   protected translation: string;
   protected expansion_panel_title: string;
 
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes) {
-      this.process_translation();
-    }
+  ngOnChanges() {
+    this.commentary = this.document.commentary;
+    this.process_translation();
   }
 
   /**
@@ -35,12 +36,12 @@ export class TranslationComponent implements OnChanges {
       this.translation = '';
       //TODO: this does not add HTML like the <10> flag. This function is part of the Fragment model,
       // not the commentary model. We will probably need to put these functions in a helper service.
-      this.commentary.lines.forEach((line: Line) => {
+      this.document.lines.forEach((line: Line) => {
         this.translation += `<p>${line.line_number}: ${line.text}</p>`;
       });
     } else {
       this.expansion_panel_title = 'Fragment translation';
-      this.translation = this.commentary.translation;
+      this.translation = this.commentary.fields.translation;
     }
   }
 }

--- a/Angular/src/app/dashboard/fragments-dashboard/fragments-dashboard.component.ts
+++ b/Angular/src/app/dashboard/fragments-dashboard/fragments-dashboard.component.ts
@@ -159,11 +159,11 @@ export class FragmentsDashboardComponent implements OnInit {
       this.fragment_form.patchValue({ [item]: fragment.commentary[item] });
     }
     // Fill the fragment context array
-    for (const i in fragment.commentary.context) {
+    for (const i in fragment.commentary.fields.context) {
       this.push_fragment_context_to_fragment_form(
-        fragment.commentary.context[i].author,
-        fragment.commentary.context[i].location,
-        fragment.commentary.context[i].text
+        fragment.commentary.fields.context[i].author,
+        fragment.commentary.fields.context[i].location,
+        fragment.commentary.fields.context[i].text
       );
     }
     // Fill the fragment lines array

--- a/Angular/src/app/models/Commentary.ts
+++ b/Angular/src/app/models/Commentary.ts
@@ -1,44 +1,56 @@
 import { Context } from '@oscc/models/Context';
-import { Line } from '@oscc/models/Line';
+
+export interface Fields {
+  apparatus: string;
+  commentary: string;
+  context: Context[];
+  differences: string;
+  metrical_analysis: string;
+  reconstruction: string;
+  translation: string;
+}
 
 /**
  * This class represents a commentary and all its data fields.
  * It is linked to a document. For example: a fragment has a commentary
  */
 export class Commentary {
-  translation = '';
-  commentary = '';
-  apparatus = '';
-  reconstruction = '';
-  differences = '';
-  metrical_analysis = '';
-  context: Context[] = [];
-
-  lines: Line[] = [];
+  // All commentary fields are stored in this interface.
+  fields: Fields;
 
   bibliography = '';
 
   constructor(commentary?: Partial<Commentary>) {
-    // Allow the partial initialisation of a fragment object
+    // Allow the partial initialisation of the object
     Object.assign(this, commentary);
   }
 
   /**
    * Converts the JSON received from the server to a Typescript object
-   * @param fragment with JSON data received from the server
+   * @param doc (object) with JSON data received from the server
    * @author Ycreak
    */
-  public set(fragment: any) {
+  public set(doc: any) {
     this.bibliography = '';
-    this.translation = 'translation' in fragment && fragment['translation'] != null ? fragment['translation'] : '';
-    this.commentary = 'commentary' in fragment && fragment['commentary'] != null ? fragment['commentary'] : '';
-    this.apparatus = 'apparatus' in fragment && fragment['apparatus'] != null ? fragment['apparatus'] : '';
-    this.reconstruction =
-      'reconstruction' in fragment && fragment['reconstruction'] != null ? fragment['reconstruction'] : '';
-    this.differences = 'differences' in fragment && fragment['differences'] != null ? fragment['differences'] : '';
-    this.metrical_analysis =
-      'metrical_analysis' in fragment && fragment['metrical_analysis'] != null ? fragment['metrical_analysis'] : '';
-    this.context = 'context' in fragment && fragment['context'] != null ? fragment['context'] : [];
+
+    const apparatus = 'apparatus' in doc && doc['apparatus'] != null ? doc['apparatus'] : '';
+    const translation = 'translation' in doc && doc['translation'] != null ? doc['translation'] : '';
+    const commentary = 'commentary' in doc && doc['commentary'] != null ? doc['commentary'] : '';
+    const reconstruction = 'reconstruction' in doc && doc['reconstruction'] != null ? doc['reconstruction'] : '';
+    const differences = 'differences' in doc && doc['differences'] != null ? doc['differences'] : '';
+    const metrical_analysis =
+      'metrical_analysis' in doc && doc['metrical_analysis'] != null ? doc['metrical_analysis'] : '';
+    const context = 'context' in doc && doc['context'] != null ? doc['context'] : [];
+
+    this.fields = {
+      apparatus: apparatus,
+      commentary: commentary,
+      context: context,
+      differences: differences,
+      metrical_analysis: metrical_analysis,
+      reconstruction: reconstruction,
+      translation: translation,
+    } as Fields;
   }
 
   /**
@@ -49,11 +61,11 @@ export class Commentary {
    */
   public has_content() {
     return (
-      this.differences != '' ||
-      this.apparatus != '' ||
-      this.translation != '' ||
-      this.commentary != '' ||
-      this.reconstruction != ''
+      this.fields.apparatus != '' ||
+      this.fields.commentary != '' ||
+      this.fields.differences != '' ||
+      this.fields.reconstruction != '' ||
+      this.fields.translation != ''
     );
   }
 }

--- a/Angular/src/app/models/Fragment.ts
+++ b/Angular/src/app/models/Fragment.ts
@@ -52,7 +52,6 @@ export class Fragment {
 
     this.commentary = new Commentary({});
     this.commentary.set(fragment);
-    this.commentary.lines = this.lines;
   }
 
   /**

--- a/Angular/src/app/overview/overview.component.html
+++ b/Angular/src/app/overview/overview.component.html
@@ -117,7 +117,6 @@
           <app-commentary
             #commentary
             [document]="this.clicked_document"
-            [commentary]="this.clicked_document.commentary"
             [translated]="this.clicked_document.translated"
             [translated]="this.translation_toggled"
             (request_column)="this.requested_column = $event">

--- a/Angular/src/app/services/bibliography-helper.service.ts
+++ b/Angular/src/app/services/bibliography-helper.service.ts
@@ -1,13 +1,17 @@
 import { Injectable } from '@angular/core';
-import { ApiService } from '@oscc/api.service';
 
+// Model imports
 import { Commentary } from '@oscc/models/Commentary';
+
+// Service imports
+import { ApiService } from '@oscc/api.service';
+import { UtilityService } from '@oscc/utility.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class BibliographyHelperService {
-  constructor(protected api: ApiService) {}
+  constructor(private utility: UtilityService, protected api: ApiService) {}
 
   /**
    * Retrieves all bib keys from the given commentary object
@@ -16,26 +20,18 @@ export class BibliographyHelperService {
    * @author Ycreak
    */
   public retrieve_bib_keys_from_commentary(commentary: Commentary): string[] {
-    const commentary_fields = [
-      'commentary',
-      'differences',
-      'apparatus',
-      'reconstruction',
-      'metrical_analysis',
-      'translation',
-    ];
     let bib_keys: string[] = [];
 
-    // Retrieve all keys for the simple string commentary fields
-    for (const key in commentary) {
-      if (commentary_fields.includes(key)) {
-        bib_keys = bib_keys.concat(this.get_bib_keys(commentary[key]));
+    const commentary_fields_keys = Object.keys(commentary.fields);
+    commentary_fields_keys.forEach((key: string) => {
+      if (this.utility.is_string(commentary.fields[key])) {
+        bib_keys = bib_keys.concat(this.get_bib_keys(commentary.fields[key]));
+      } else if (this.utility.is_array(commentary.fields[key])) {
+        commentary.fields[key].forEach((obj: any) => {
+          bib_keys = bib_keys.concat(this.get_bib_keys(obj.text));
+        });
       }
-    }
-    // Retrieve keys for the context fields
-    for (const i in commentary.context) {
-      bib_keys = bib_keys.concat(this.get_bib_keys(commentary.context[i].text));
-    }
+    });
     bib_keys = [...new Set(bib_keys)];
     return bib_keys;
   }

--- a/Angular/src/app/utility.service.ts
+++ b/Angular/src/app/utility.service.ts
@@ -148,7 +148,7 @@ export class UtilityService {
    * @returns new array with item pushed
    * @author Ycreak
    */
-  public push_to_array(item, array): Array<any> {
+  public push_to_array(item: any, array: Array<any>): Array<any> {
     array.push(item);
     return array;
   }
@@ -164,7 +164,7 @@ export class UtilityService {
     return array;
   }
 
-  public is_empty_array(array): boolean {
+  public is_empty_array(array: Array<any>): boolean {
     if (Array.isArray(array) && array.length) {
       return false;
     } else {
@@ -172,6 +172,16 @@ export class UtilityService {
     }
   }
 
+  public is_array(x: any) {
+    return Array.isArray(x);
+  }
+
+  /**
+   * Checks if given object is a string
+   */
+  public is_string(x: any) {
+    return Object.prototype.toString.call(x) === '[object String]';
+  }
   /**
    * This function moves an element within an array from the given location to the given new location
    * @param arr in which the moving should be done


### PR DESCRIPTION
This PR refactors all fields from the commentary to an interface called fields. This will allow for easy looping over the content fields for processing later on (like adding HTML or interpreting bib keys.