### PR TITLE
Linked commentaries now correctly show translation

### DIFF
--- a/angular/src/app/commentary/commentary.component.html
+++ b/angular/src/app/commentary/commentary.component.html
@@ -24,7 +24,7 @@
   <div>
     <ng-container
       [ngTemplateOutlet]="commentary_column_template"
-      [ngTemplateOutletContext]="{ given_commentary: this.commentary }">
+      [ngTemplateOutletContext]="{ given_document: this.document }">
     </ng-container>
   </div>
 
@@ -50,34 +50,34 @@
       </h6>
       <ng-container
         [ngTemplateOutlet]="commentary_column_template"
-        [ngTemplateOutletContext]="{ given_commentary: linked_fragment.commentary }"></ng-container>
+        [ngTemplateOutletContext]="{ given_document: linked_fragment }"></ng-container>
     </div>
   </div>
 </ng-template>
 
-<ng-template #commentary_column_template let-commentary="given_commentary">
+<ng-template #commentary_column_template let-document="given_document">
   <!-- Show the fragment's translation or original text -->
-  <ng-container *ngIf="commentary.fields.translation">
+  <ng-container *ngIf="document.commentary.fields.translation">
     <app-translation [document]="document" [translated]="this.translated"></app-translation>
     <hr
   /></ng-container>
 
-  <ng-container *ngIf="commentary.fields.apparatus">
+  <ng-container *ngIf="document.commentary.fields.apparatus">
     <app-general-commentary-field
-      [content]="commentary.fields.apparatus"
+      [content]="document.commentary.fields.apparatus"
       [title]="'Apparatus Criticus'"></app-general-commentary-field>
     <hr
   /></ng-container>
 
-  <ng-container *ngIf="commentary.fields.differences">
+  <ng-container *ngIf="document.commentary.fields.differences">
     <app-general-commentary-field
-      [content]="commentary.fields.differences"
+      [content]="document.commentary.fields.differences"
       [title]="'Editorial Differences'"></app-general-commentary-field>
     <hr
   /></ng-container>
 
-  <ng-container *ngIf="!this.utility.is_empty_array(commentary.fields.context)">
-    <div *ngFor="let current_context of commentary.fields.context">
+  <ng-container *ngIf="!this.utility.is_empty_array(document.commentary.fields.context)">
+    <div *ngFor="let current_context of document.commentary.fields.context">
       <mat-expansion-panel>
         <mat-expansion-panel-header class="citation-context-mat-exp-header">
           <mat-panel-title>
@@ -98,23 +98,23 @@
     <hr />
   </ng-container>
 
-  <ng-container *ngIf="commentary.fields.commentary">
+  <ng-container *ngIf="document.commentary.fields.commentary">
     <app-general-commentary-field
-      [content]="commentary.fields.commentary"
+      [content]="document.commentary.fields.commentary"
       [title]="'Fragment Commentary'"></app-general-commentary-field>
     <hr
   /></ng-container>
 
-  <ng-container *ngIf="commentary.fields.metrical_analysis">
+  <ng-container *ngIf="document.commentary.fields.metrical_analysis">
     <app-general-commentary-field
-      [content]="commentary.fields.metrical_analysis"
+      [content]="document.commentary.fields.metrical_analysis"
       [title]="'Metrical Analysis'"></app-general-commentary-field>
     <hr
   /></ng-container>
 
-  <ng-container *ngIf="commentary.fields.reconstuction">
+  <ng-container *ngIf="document.commentary.fields.reconstuction">
     <app-general-commentary-field
-      [content]="commentary.fields.reconstruction"
+      [content]="document.commentary.fields.reconstruction"
       [title]="'Fragment Reconstruction'"></app-general-commentary-field>
     <hr
   /></ng-container>

--- a/angular/src/app/commentary/translation/translation.component.ts
+++ b/angular/src/app/commentary/translation/translation.component.ts
@@ -22,7 +22,9 @@ export class TranslationComponent implements OnChanges {
   protected expansion_panel_title: string;
 
   ngOnChanges() {
+    console.log(this.document);
     this.commentary = this.document.commentary;
+    console.log(this.commentary);
     this.process_translation();
   }
 

--- a/angular/src/app/overview/overview.component.html
+++ b/angular/src/app/overview/overview.component.html
@@ -64,7 +64,7 @@
   <a href="https://github.com/Ycreak/OpensourceClassicCommentary/" target="_blank" mat-menu-item>Documentation</a>
   <button (click)="this.settings.open_settings()" mat-menu-item>Settings</button>
   <button (click)="this.dialog.open_about_dialog()" mat-menu-item>About</button>
-  <div mat-menu-item>V24.01.29</div>
+  <div mat-menu-item>V24.02.10</div>
 </mat-menu>
 
 <!-- Display for if server is down -->

--- a/angular/src/app/playground/playground.component.ts
+++ b/angular/src/app/playground/playground.component.ts
@@ -78,7 +78,7 @@ export class PlaygroundComponent implements OnInit {
     this.set_canvas_event_handlers();
     this.init_canvas_settings();
 
-    this.request_documents({ title: 'Eumenides' });
+    //this.request_documents({ title: 'Eumenides' });
   }
 
   /**
@@ -535,7 +535,6 @@ export class PlaygroundComponent implements OnInit {
   protected request_commentary(): void {
     const clicked_document = this.playground.canvas.getActiveObjects()[0];
     if (!this.is_note(clicked_document)) {
-      console.log(clicked_document);
       const full_document = this.utility.filter_array(this.documents, clicked_document.identifier)[0];
       this.commentary.request(full_document);
       window.scroll(0, 0);


### PR DESCRIPTION
This PR fixes a small issue where linked commentaries could not show translations due to the implementation of the fragment translation/original text feature. It now shows a translation, though the implementation still needs revision.

For example: open a column. Translate everything. Close the column, open a new one. Request commentary: this commentary is now translated by default, which is not what we want. Might be a simple fix. 