### PR TITLE
Fixed spinner for fragments and testimonia

### DIFF
--- a/angular/src/app/services/api/fragments.service.ts
+++ b/angular/src/app/services/api/fragments.service.ts
@@ -46,6 +46,7 @@ export class FragmentsApiService extends ApiService {
    */
   public request_index(): Observable<any> {
     return new Observable((observer) => {
+      this.spinner_on();
       this.fragments_index = [];
       this.post(this.FlaskURL, this.index, {}, this.get_header).subscribe({
         next: (data) => {
@@ -57,6 +58,7 @@ export class FragmentsApiService extends ApiService {
               name: value[3],
             } as fragments_index);
           });
+          this.spinner_off();
           observer.next(this.fragments_index);
           observer.complete();
         },
@@ -73,6 +75,7 @@ export class FragmentsApiService extends ApiService {
    */
   public request_documents(filter: any): Observable<any> {
     return new Observable((observer) => {
+      this.spinner_on();
       this.post(this.FlaskURL, this.retrieve, filter, this.get_header).subscribe({
         next: (data) => {
           const documents: any[] = [];
@@ -81,6 +84,7 @@ export class FragmentsApiService extends ApiService {
             new_fragment.set(value);
             documents.push(new_fragment);
           });
+          this.spinner_off();
           observer.next(documents);
           observer.complete();
         },

--- a/angular/src/app/services/api/testimonia.service.ts
+++ b/angular/src/app/services/api/testimonia.service.ts
@@ -44,6 +44,7 @@ export class TestimoniaApiService extends ApiService {
    */
   public request_index(): Observable<any> {
     return new Observable((observer) => {
+      this.spinner_on();
       this.testimonia_index = [];
       this.post(this.FlaskURL, this.index, {}, this.get_header).subscribe({
         next: (data) => {
@@ -53,6 +54,7 @@ export class TestimoniaApiService extends ApiService {
               name: value[1],
             } as testimonia_index);
           });
+          this.spinner_off();
           observer.next(this.testimonia_index);
           observer.complete();
         },
@@ -69,6 +71,7 @@ export class TestimoniaApiService extends ApiService {
    */
   public request_documents(filter: any): Observable<any> {
     return new Observable((observer) => {
+      this.spinner_on();
       this.post(this.FlaskURL, this.retrieve, filter, this.get_header).subscribe((data: any) => {
         const documents: any[] = [];
         data.forEach((value: any) => {
@@ -76,6 +79,7 @@ export class TestimoniaApiService extends ApiService {
           new_testimonium.set(value);
           documents.push(new_testimonium);
         });
+        this.spinner_off();
         observer.next(documents);
         observer.complete();
       });


### PR DESCRIPTION
I forgot adding the spinner when migrating to the new fragment and testimonia api services.