### PR TITLE
Playground testimonia

### DIFF
--- a/angular/src/app/models/Playground.ts
+++ b/angular/src/app/models/Playground.ts
@@ -323,7 +323,7 @@ export class Playground {
   public is_note(thing: any): boolean {
     return thing.backgroundColor == '#F0C086';
   }
-  
+
   /**
    * Checks if the given object is a document
    * @param thing (object)
@@ -331,7 +331,7 @@ export class Playground {
    * @author Ycreak
    */
   public is_document(thing: any): boolean {
-    return ('identifier' in thing)
+    return 'identifier' in thing;
     //thing.backgroundColor == '#F0C086';
   }
 }

--- a/angular/src/app/models/Playground.ts
+++ b/angular/src/app/models/Playground.ts
@@ -83,7 +83,6 @@ export class Playground {
       } else if (doc.document_type == environment.testimonium) {
         this.add_testimonium(doc, top, this.canvas.vptCoords.tr.x - offset_left);
       }
-
       top += offset_next_document;
     });
   }

--- a/angular/src/app/models/Playground.ts
+++ b/angular/src/app/models/Playground.ts
@@ -231,7 +231,7 @@ export class Playground {
     this.canvas.on('mouse:up', () => {
       // Whenever we move a fragment, we set its colour. This allows the distinction between existing and new fragments
       const activeObject = this.canvas.getActiveObject();
-      if (activeObject && !this.is_note(activeObject)) {
+      if (activeObject && this.is_document(activeObject)) {
         activeObject._objects[0].set('fill', '#9BA8F2'); // Change color to blue
         this.canvas.renderAll();
       }
@@ -322,5 +322,16 @@ export class Playground {
    */
   public is_note(thing: any): boolean {
     return thing.backgroundColor == '#F0C086';
+  }
+  
+  /**
+   * Checks if the given object is a document
+   * @param thing (object)
+   * @return boolean
+   * @author Ycreak
+   */
+  public is_document(thing: any): boolean {
+    return ('identifier' in thing)
+    //thing.backgroundColor == '#F0C086';
   }
 }

--- a/angular/src/app/models/Playground.ts
+++ b/angular/src/app/models/Playground.ts
@@ -2,7 +2,7 @@ import { fabric } from 'fabric';
 import { environment } from '@src/environments/environment';
 
 // Service imports
-import {FabricService} from '@oscc/playground/services/fabric.service';
+import { FabricService } from '@oscc/playground/services/fabric.service';
 
 export class Playground {
   _id: string;
@@ -35,10 +35,7 @@ export class Playground {
   retrieved_titles: string[];
   retrieved_editors: string[];
 
-  constructor(
-    private fabric: FabricService
-  ) {
-  }
+  constructor(private fabric: FabricService) {}
 
   /**
    * Inits various canvas settings
@@ -145,8 +142,8 @@ export class Playground {
   private add_fragment(fragment: any, top: number, left: number): void {
     const fill = '#3F51B5';
 
-    const header = this.fabric.create_header(fragment, this.font_size)
-    const lines = this.fabric.create_lines(fragment, this.font_size)
+    const header = this.fabric.create_header(fragment, this.font_size);
+    const lines = this.fabric.create_lines(fragment, this.font_size);
     const text_group = new fabric.Group([header, lines], {
       hasBorders: true,
       padding: 10,
@@ -161,7 +158,7 @@ export class Playground {
     });
     this.canvas.add(group);
   }
-  
+
   /**
    * Adds the given fragment to the canvas
    * @author Ycreak
@@ -169,8 +166,8 @@ export class Playground {
   private add_testimonium(testimonium: any, top: number, left: number): void {
     const fill = 'orange';
 
-    const header = this.fabric.create_header(testimonium, this.font_size)
-    const lines = this.fabric.create_text(testimonium, this.font_size)
+    const header = this.fabric.create_header(testimonium, this.font_size);
+    const lines = this.fabric.create_text(testimonium, this.font_size);
     const text_group = new fabric.Group([header, lines], {
       hasBorders: true,
       padding: 10,
@@ -181,7 +178,12 @@ export class Playground {
       top: top,
       left: left,
       // We save the document identifier for finding the document in this.documents whenever we need it for something
-      identifier: { author: testimonium.author, title: testimonium.title, editor: testimonium.editor, name: testimonium.name },
+      identifier: {
+        author: testimonium.author,
+        title: testimonium.title,
+        editor: testimonium.editor,
+        name: testimonium.name,
+      },
     });
     this.canvas.add(group);
   }

--- a/angular/src/app/models/Playground.ts
+++ b/angular/src/app/models/Playground.ts
@@ -1,5 +1,8 @@
-import { environment } from '@src/environments/environment';
 import { fabric } from 'fabric';
+import { environment } from '@src/environments/environment';
+
+// Service imports
+import {FabricService} from '@oscc/playground/services/fabric.service';
 
 export class Playground {
   _id: string;
@@ -32,9 +35,9 @@ export class Playground {
   retrieved_titles: string[];
   retrieved_editors: string[];
 
-  constructor(playground?: Partial<Playground>) {
-    // Allow the partial initialisation of a playground object
-    Object.assign(this, playground);
+  constructor(
+    private fabric: FabricService
+  ) {
   }
 
   /**
@@ -81,7 +84,7 @@ export class Playground {
       if (doc.document_type == environment.fragment) {
         this.add_fragment(doc, top, this.canvas.vptCoords.tr.x - offset_left);
       } else if (doc.document_type == environment.testimonium) {
-        console.log('Not implemented');
+        this.add_testimonium(doc, top, this.canvas.vptCoords.tr.x - offset_left);
       }
 
       top += offset_next_document;
@@ -140,47 +143,45 @@ export class Playground {
    * @author Ycreak
    */
   private add_fragment(fragment: any, top: number, left: number): void {
-    const header_text = `Fragment ${fragment.name}`;
-    const header = new fabric.Text(header_text, {
-      fontSize: this.font_size,
-      fontWeight: 'bold',
-      originX: 'left',
-      originY: 'bottom',
-    });
-    let lines_text = '';
-    fragment.lines.forEach((line: any) => {
-      lines_text += `${line.line_number}: ${line.text}\n`;
-    });
-    const lines = new fabric.IText(lines_text, {
-      fontSize: this.font_size,
-      originX: 'left',
-    });
+    const fill = '#3F51B5';
 
-    // Add formatting to the lines
-    //lines = this.format(lines);
-
+    const header = this.fabric.create_header(fragment, this.font_size)
+    const lines = this.fabric.create_lines(fragment, this.font_size)
     const text_group = new fabric.Group([header, lines], {
       hasBorders: true,
       padding: 10,
     });
-    const textBoundingRect = text_group.getBoundingRect();
-    const background_and_border = new fabric.Rect({
-      top: textBoundingRect.top,
-      left: textBoundingRect.left,
-      width: textBoundingRect.width,
-      height: textBoundingRect.height,
-      fill: '#3F51B5',
-      rx: 10,
-      ry: 10,
-      stroke: 'black',
-      strokeWidth: 1,
-    });
-
-    const group = new fabric.Group([background_and_border, text_group], {
+    const text_bounding_rect = text_group.getBoundingRect();
+    const box = this.fabric.create_box(text_bounding_rect, fill);
+    const group = new fabric.Group([box, text_group], {
       top: top,
       left: left,
       // We save the document identifier for finding the document in this.documents whenever we need it for something
       identifier: { author: fragment.author, title: fragment.title, editor: fragment.editor, name: fragment.name },
+    });
+    this.canvas.add(group);
+  }
+  
+  /**
+   * Adds the given fragment to the canvas
+   * @author Ycreak
+   */
+  private add_testimonium(testimonium: any, top: number, left: number): void {
+    const fill = 'orange';
+
+    const header = this.fabric.create_header(testimonium, this.font_size)
+    const lines = this.fabric.create_text(testimonium, this.font_size)
+    const text_group = new fabric.Group([header, lines], {
+      hasBorders: true,
+      padding: 10,
+    });
+    const text_bounding_rect = text_group.getBoundingRect();
+    const box = this.fabric.create_box(text_bounding_rect, fill);
+    const group = new fabric.Group([box, text_group], {
+      top: top,
+      left: left,
+      // We save the document identifier for finding the document in this.documents whenever we need it for something
+      identifier: { author: testimonium.author, title: testimonium.title, editor: testimonium.editor, name: testimonium.name },
     });
     this.canvas.add(group);
   }

--- a/angular/src/app/overview/overview.component.html
+++ b/angular/src/app/overview/overview.component.html
@@ -64,7 +64,7 @@
   <a href="https://github.com/Ycreak/OpensourceClassicCommentary/" target="_blank" mat-menu-item>Documentation</a>
   <button (click)="this.settings.open_settings()" mat-menu-item>Settings</button>
   <button (click)="this.dialog.open_about_dialog()" mat-menu-item>About</button>
-  <div mat-menu-item>V24.02.23</div>
+  <div mat-menu-item>V24.04.28</div>
 </mat-menu>
 
 <!-- Display for if server is down -->

--- a/angular/src/app/playground/playground.component.html
+++ b/angular/src/app/playground/playground.component.html
@@ -49,18 +49,18 @@
           class="playground-icon"
           src="assets\icons\ByteDanceIconPark\9069780_write_icon.png"
           (click)="this.playground.toggle_drawing_mode()" />
-        <img
-          id="playground_arrow_btn"
-          class="playground-icon"
-          src="assets\icons\ByteDanceIconPark\9068687_arrow_right_up_icon.png" />
-        <img
-          id="playground_line_btn"
-          class="playground-icon"
-          src="assets\icons\ByteDanceIconPark\9069299_line_icon.png" />
-        <img
-          id="playground_rectangle_btn"
-          class="playground-icon"
-          src="assets\icons\ByteDanceIconPark\9070071_square_icon.png" />
+        <!--<img-->
+          <!--id="playground_arrow_btn"-->
+          <!--class="playground-icon"-->
+          <!--src="assets\icons\ByteDanceIconPark\9068687_arrow_right_up_icon.png" />-->
+        <!--<img-->
+          <!--id="playground_line_btn"-->
+          <!--class="playground-icon"-->
+          <!--src="assets\icons\ByteDanceIconPark\9069299_line_icon.png" />-->
+        <!--<img-->
+          <!--id="playground_rectangle_btn"-->
+          <!--class="playground-icon"-->
+          <!--src="assets\icons\ByteDanceIconPark\9070071_square_icon.png" />-->
       </div>
 
       <div id="playground-history-tools" class="playground-tool-group">
@@ -77,33 +77,33 @@
       </div>
 
       <div id="playground-load-save-tools" class="playground-tool-group">
-        <img
-          id="playground_save_btn"
-          class="playground-icon"
-          src="assets\icons\ByteDanceIconPark\9070374_hard_disk_one_icon.png"
-          (click)="this.save_playground()" />
-        <img
-          id="playground_load_btn"
-          class="playground-icon"
-          src="assets\icons\ByteDanceIconPark\9068981_folder_open_icon.png"
-          (click)="this.load_playground()" />
-        <img
-          id="playground_delete_btn"
-          class="playground-icon"
-          src="assets\icons\ByteDanceIconPark\9069053_folder_delete_icon.png"
-          (click)="this.delete_playground()" />
+        <!--<img-->
+          <!--id="playground_save_btn"-->
+          <!--class="playground-icon"-->
+          <!--src="assets\icons\ByteDanceIconPark\9070374_hard_disk_one_icon.png"-->
+          <!--(click)="this.save_playground()" />-->
+        <!--<img-->
+          <!--id="playground_load_btn"-->
+          <!--class="playground-icon"-->
+          <!--src="assets\icons\ByteDanceIconPark\9068981_folder_open_icon.png"-->
+          <!--(click)="this.load_playground()" />-->
+        <!--<img-->
+          <!--id="playground_delete_btn"-->
+          <!--class="playground-icon"-->
+          <!--src="assets\icons\ByteDanceIconPark\9069053_folder_delete_icon.png"-->
+          <!--(click)="this.delete_playground()" />-->
       </div>
       <div id="playground-sharing-tools" class="playground-tool-group">
-        <img
-          id="playground_share_btn"
-          class="playground-icon"
-          src="assets\icons\ByteDanceIconPark\9071373_people_plus_one_icon.png"
-          (click)="this.share_playground()" />
-        <img
-          id="playground_join_btn"
-          class="playground-icon"
-          src="assets\icons\ByteDanceIconPark\9071420_people_download_icon.png"
-          (click)="this.join_playground()" />
+        <!--<img-->
+          <!--id="playground_share_btn"-->
+          <!--class="playground-icon"-->
+          <!--src="assets\icons\ByteDanceIconPark\9071373_people_plus_one_icon.png"-->
+          <!--(click)="this.share_playground()" />-->
+        <!--<img-->
+          <!--id="playground_join_btn"-->
+          <!--class="playground-icon"-->
+          <!--src="assets\icons\ByteDanceIconPark\9071420_people_download_icon.png"-->
+          <!--(click)="this.join_playground()" />-->
       </div>
     </div>
   </div>

--- a/angular/src/app/playground/playground.component.html
+++ b/angular/src/app/playground/playground.component.html
@@ -50,17 +50,17 @@
           src="assets\icons\ByteDanceIconPark\9069780_write_icon.png"
           (click)="this.playground.toggle_drawing_mode()" />
         <!--<img-->
-          <!--id="playground_arrow_btn"-->
-          <!--class="playground-icon"-->
-          <!--src="assets\icons\ByteDanceIconPark\9068687_arrow_right_up_icon.png" />-->
+        <!--id="playground_arrow_btn"-->
+        <!--class="playground-icon"-->
+        <!--src="assets\icons\ByteDanceIconPark\9068687_arrow_right_up_icon.png" />-->
         <!--<img-->
-          <!--id="playground_line_btn"-->
-          <!--class="playground-icon"-->
-          <!--src="assets\icons\ByteDanceIconPark\9069299_line_icon.png" />-->
+        <!--id="playground_line_btn"-->
+        <!--class="playground-icon"-->
+        <!--src="assets\icons\ByteDanceIconPark\9069299_line_icon.png" />-->
         <!--<img-->
-          <!--id="playground_rectangle_btn"-->
-          <!--class="playground-icon"-->
-          <!--src="assets\icons\ByteDanceIconPark\9070071_square_icon.png" />-->
+        <!--id="playground_rectangle_btn"-->
+        <!--class="playground-icon"-->
+        <!--src="assets\icons\ByteDanceIconPark\9070071_square_icon.png" />-->
       </div>
 
       <div id="playground-history-tools" class="playground-tool-group">
@@ -78,32 +78,32 @@
 
       <div id="playground-load-save-tools" class="playground-tool-group">
         <!--<img-->
-          <!--id="playground_save_btn"-->
-          <!--class="playground-icon"-->
-          <!--src="assets\icons\ByteDanceIconPark\9070374_hard_disk_one_icon.png"-->
-          <!--(click)="this.save_playground()" />-->
+        <!--id="playground_save_btn"-->
+        <!--class="playground-icon"-->
+        <!--src="assets\icons\ByteDanceIconPark\9070374_hard_disk_one_icon.png"-->
+        <!--(click)="this.save_playground()" />-->
         <!--<img-->
-          <!--id="playground_load_btn"-->
-          <!--class="playground-icon"-->
-          <!--src="assets\icons\ByteDanceIconPark\9068981_folder_open_icon.png"-->
-          <!--(click)="this.load_playground()" />-->
+        <!--id="playground_load_btn"-->
+        <!--class="playground-icon"-->
+        <!--src="assets\icons\ByteDanceIconPark\9068981_folder_open_icon.png"-->
+        <!--(click)="this.load_playground()" />-->
         <!--<img-->
-          <!--id="playground_delete_btn"-->
-          <!--class="playground-icon"-->
-          <!--src="assets\icons\ByteDanceIconPark\9069053_folder_delete_icon.png"-->
-          <!--(click)="this.delete_playground()" />-->
+        <!--id="playground_delete_btn"-->
+        <!--class="playground-icon"-->
+        <!--src="assets\icons\ByteDanceIconPark\9069053_folder_delete_icon.png"-->
+        <!--(click)="this.delete_playground()" />-->
       </div>
       <div id="playground-sharing-tools" class="playground-tool-group">
         <!--<img-->
-          <!--id="playground_share_btn"-->
-          <!--class="playground-icon"-->
-          <!--src="assets\icons\ByteDanceIconPark\9071373_people_plus_one_icon.png"-->
-          <!--(click)="this.share_playground()" />-->
+        <!--id="playground_share_btn"-->
+        <!--class="playground-icon"-->
+        <!--src="assets\icons\ByteDanceIconPark\9071373_people_plus_one_icon.png"-->
+        <!--(click)="this.share_playground()" />-->
         <!--<img-->
-          <!--id="playground_join_btn"-->
-          <!--class="playground-icon"-->
-          <!--src="assets\icons\ByteDanceIconPark\9071420_people_download_icon.png"-->
-          <!--(click)="this.join_playground()" />-->
+        <!--id="playground_join_btn"-->
+        <!--class="playground-icon"-->
+        <!--src="assets\icons\ByteDanceIconPark\9071420_people_download_icon.png"-->
+        <!--(click)="this.join_playground()" />-->
       </div>
     </div>
   </div>

--- a/angular/src/app/playground/playground.component.ts
+++ b/angular/src/app/playground/playground.component.ts
@@ -13,7 +13,7 @@ import { AuthService } from '@oscc/auth/auth.service';
 import { CommentaryService } from '@oscc/commentary/commentary.service';
 import { FragmentsApiService } from '@oscc/services/api/fragments.service';
 import { UtilityService } from '@oscc/utility.service';
-import {FabricService} from './services/fabric.service';
+import { FabricService } from './services/fabric.service';
 
 import { FormatterService } from './services/formatter.service';
 
@@ -76,7 +76,7 @@ export class PlaygroundComponent implements OnInit {
     protected api: ApiService,
     protected fragments_api: FragmentsApiService,
     protected utility: UtilityService,
-    protected dialog: DialogService,
+    protected dialog: DialogService
   ) {}
 
   ngOnInit(): void {
@@ -181,15 +181,15 @@ export class PlaygroundComponent implements OnInit {
       if (data) {
         // TODO: fix this
         //const playground = new Playground({
-          //_id: this.playground._id,
-          //owner: this.auth_service.current_user_name,
-          //name: data.name,
-          //canvas: this.playground.canvas.toJSON(),
+        //_id: this.playground._id,
+        //owner: this.auth_service.current_user_name,
+        //name: data.name,
+        //canvas: this.playground.canvas.toJSON(),
         //});
         //if (data.button == 'save') {
-          //this.api.save_playground(playground);
+        //this.api.save_playground(playground);
         //} else if (data.button == 'create') {
-          //this.api.create_playground(playground);
+        //this.api.create_playground(playground);
         //}
       }
     });

--- a/angular/src/app/playground/playground.component.ts
+++ b/angular/src/app/playground/playground.component.ts
@@ -13,6 +13,7 @@ import { AuthService } from '@oscc/auth/auth.service';
 import { CommentaryService } from '@oscc/commentary/commentary.service';
 import { FragmentsApiService } from '@oscc/services/api/fragments.service';
 import { UtilityService } from '@oscc/utility.service';
+import {FabricService} from './services/fabric.service';
 
 import { FormatterService } from './services/formatter.service';
 
@@ -69,16 +70,17 @@ export class PlaygroundComponent implements OnInit {
     private api_interface: ApiInterfaceService,
     private auth_service: AuthService,
     private commentary: CommentaryService,
+    private fabric: FabricService,
     private formatter: FormatterService,
+    private mat_dialog: MatDialog,
     protected api: ApiService,
     protected fragments_api: FragmentsApiService,
     protected utility: UtilityService,
     protected dialog: DialogService,
-    private mat_dialog: MatDialog
   ) {}
 
   ngOnInit(): void {
-    this.playground = new Playground({});
+    this.playground = new Playground(this.fabric);
     this.playground.canvas = new fabric.Canvas('playground_canvas');
     this.playground.set_event_handlers();
     this.playground.init();
@@ -177,17 +179,18 @@ export class PlaygroundComponent implements OnInit {
     });
     dialogRef.afterClosed().subscribe((data: any) => {
       if (data) {
-        const playground = new Playground({
-          _id: this.playground._id,
-          owner: this.auth_service.current_user_name,
-          name: data.name,
-          canvas: this.playground.canvas.toJSON(),
-        });
-        if (data.button == 'save') {
-          this.api.save_playground(playground);
-        } else if (data.button == 'create') {
-          this.api.create_playground(playground);
-        }
+        // TODO: fix this
+        //const playground = new Playground({
+          //_id: this.playground._id,
+          //owner: this.auth_service.current_user_name,
+          //name: data.name,
+          //canvas: this.playground.canvas.toJSON(),
+        //});
+        //if (data.button == 'save') {
+          //this.api.save_playground(playground);
+        //} else if (data.button == 'create') {
+          //this.api.create_playground(playground);
+        //}
       }
     });
   }

--- a/angular/src/app/playground/playground.component.ts
+++ b/angular/src/app/playground/playground.component.ts
@@ -86,6 +86,7 @@ export class PlaygroundComponent implements OnInit {
     this.playground.init();
 
     this.request_documents('fragments', { title: 'Eumenides' });
+    //this.request_documents('testimonia', { author: 'Accius' });
   }
 
   /**

--- a/angular/src/app/playground/services/fabric.service.spec.ts
+++ b/angular/src/app/playground/services/fabric.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FabricService } from './fabric.service';
+
+describe('FabricService', () => {
+  let service: FabricService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FabricService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/angular/src/app/playground/services/fabric.service.ts
+++ b/angular/src/app/playground/services/fabric.service.ts
@@ -54,11 +54,59 @@ export class FabricService {
     doc.lines.forEach((line: any) => {
       lines_text += `${line.line_number}: ${line.text}\n`;
     });
+    // Remove the last superfluous carriage return (I have no idea why -1 instead of -2)
+    lines_text = lines_text.slice(0, -1)
+
+    // Get the positions of the cursive text
+    const positions = this.get_style_positions(lines_text, '$');
+    // Remove the delimiters from the text
+    lines_text = lines_text.split('$').join('');
+
     const lines = new fabric.IText(lines_text, {
       fontSize: font_size,
       originX: 'left',
     });
+
+    // We removed the delimiters, so after every tuple, we need to subtract two additional positions from
+    // the positions inside the tuples to compensate for the removed delimiters. 
+    let tuple_counter = 0;
+    positions.forEach((tuple: any) => {
+      lines.setSelectionStyles({ fontStyle: 'italic' }, tuple[0] - tuple_counter, tuple[1] - tuple_counter);
+      tuple_counter += 2;
+    })
     return lines;
+  }
+
+  /**
+   * Returns the positions where style delimiters are in the given string.
+   * For example, for the string "h$e$llo $there$", [[1,3],[8,14]] is returned
+   * @param text (string)
+   * @param delmiter (string)
+   * @return list of tuples
+   * @author Ycreak
+   */
+  private get_style_positions(lines_text: string, delimiter: string) {
+     const positions: number[] = [];
+     let index = lines_text.indexOf(delimiter);
+
+     while (index !== -1) {
+        positions.push(index);
+        index = lines_text.indexOf(delimiter, index + 1);
+     }
+
+    const tuples = positions.reduce((acc: [number][], value: number, index: number) => {
+     if (index % 2 === 0) {
+        // Start a new tuple with the current number
+        acc.push([value]);
+     } else {
+        // Add the current number to the last tuple in acc
+        const lastTuple = acc[acc.length - 1];
+        lastTuple.push(value);
+     }
+     return acc;
+    }, []);
+
+    return tuples;
   }
 
   public create_box(text_bounding_rect: any, fill: string): fabric.Rect {

--- a/angular/src/app/playground/services/fabric.service.ts
+++ b/angular/src/app/playground/services/fabric.service.ts
@@ -55,7 +55,7 @@ export class FabricService {
       lines_text += `${line.line_number}: ${line.text}\n`;
     });
     // Remove the last superfluous carriage return (I have no idea why -1 instead of -2)
-    lines_text = lines_text.slice(0, -1)
+    lines_text = lines_text.slice(0, -1);
 
     // Get the positions of the cursive text
     const positions = this.get_style_positions(lines_text, '$');
@@ -68,12 +68,12 @@ export class FabricService {
     });
 
     // We removed the delimiters, so after every tuple, we need to subtract two additional positions from
-    // the positions inside the tuples to compensate for the removed delimiters. 
+    // the positions inside the tuples to compensate for the removed delimiters.
     let tuple_counter = 0;
     positions.forEach((tuple: any) => {
       lines.setSelectionStyles({ fontStyle: 'italic' }, tuple[0] - tuple_counter, tuple[1] - tuple_counter);
       tuple_counter += 2;
-    })
+    });
     return lines;
   }
 
@@ -86,24 +86,24 @@ export class FabricService {
    * @author Ycreak
    */
   private get_style_positions(lines_text: string, delimiter: string) {
-     const positions: number[] = [];
-     let index = lines_text.indexOf(delimiter);
+    const positions: number[] = [];
+    let index = lines_text.indexOf(delimiter);
 
-     while (index !== -1) {
-        positions.push(index);
-        index = lines_text.indexOf(delimiter, index + 1);
-     }
+    while (index !== -1) {
+      positions.push(index);
+      index = lines_text.indexOf(delimiter, index + 1);
+    }
 
     const tuples = positions.reduce((acc: [number][], value: number, index: number) => {
-     if (index % 2 === 0) {
+      if (index % 2 === 0) {
         // Start a new tuple with the current number
         acc.push([value]);
-     } else {
+      } else {
         // Add the current number to the last tuple in acc
         const lastTuple = acc[acc.length - 1];
         lastTuple.push(value);
-     }
-     return acc;
+      }
+      return acc;
     }, []);
 
     return tuples;

--- a/angular/src/app/playground/services/fabric.service.ts
+++ b/angular/src/app/playground/services/fabric.service.ts
@@ -4,13 +4,10 @@ import { fabric } from 'fabric';
 import { UtilityService } from '@oscc/utility.service';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class FabricService {
-
-  constructor(
-    private utility: UtilityService
-  ) { }
+  constructor(private utility: UtilityService) {}
 
   /**
    * Creates a document header
@@ -29,7 +26,7 @@ export class FabricService {
     });
     return header;
   }
-  
+
   /**
    * Creates the text for a fabric object
    * @param doc (document)

--- a/angular/src/app/playground/services/fabric.service.ts
+++ b/angular/src/app/playground/services/fabric.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@angular/core';
+import { fabric } from 'fabric';
+
+import { UtilityService } from '@oscc/utility.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FabricService {
+
+  constructor(
+    private utility: UtilityService
+  ) { }
+
+  /**
+   * Creates a document header
+   * @param doc (document)
+   * @param font_size (number)
+   * @return fabric.Text
+   * @author Ycreak
+   */
+  public create_header(doc: any, font_size: number): fabric.Text {
+    const header_text = `${this.utility.capitalize_word(doc.document_type)} ${doc.name}`;
+    const header = new fabric.Text(header_text, {
+      fontSize: font_size,
+      fontWeight: 'bold',
+      originX: 'left',
+      originY: 'bottom',
+    });
+    return header;
+  }
+  
+  /**
+   * Creates the text for a fabric object
+   * @param doc (document)
+   * @param font_size (number)
+   * @return fabric.Text
+   * @author Ycreak
+   */
+  public create_text(doc: any, font_size: number): fabric.Text {
+    return new fabric.Textbox(doc.text, {
+      originX: 'left',
+      width: 300,
+      fontSize: font_size,
+    });
+  }
+
+  /**
+   * Creates the lines for a fabric object
+   * @param doc (document)
+   * @param font_size (number)
+   * @return fabric.Text
+   * @author Ycreak
+   */
+  public create_lines(doc: any, font_size: number): fabric.Text {
+    let lines_text = '';
+    doc.lines.forEach((line: any) => {
+      lines_text += `${line.line_number}: ${line.text}\n`;
+    });
+    const lines = new fabric.IText(lines_text, {
+      fontSize: font_size,
+      originX: 'left',
+    });
+    return lines;
+  }
+
+  public create_box(text_bounding_rect: any, fill: string): fabric.Rect {
+    return new fabric.Rect({
+      top: text_bounding_rect.top,
+      left: text_bounding_rect.left,
+      width: text_bounding_rect.width,
+      height: text_bounding_rect.height,
+      fill: fill,
+      rx: 10,
+      ry: 10,
+      stroke: 'black',
+      strokeWidth: 1,
+    });
+  }
+}

--- a/angular/src/app/playground/services/formatter.service.ts
+++ b/angular/src/app/playground/services/formatter.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { environment } from '@src/environments/environment';
 
-import {Fragment} from '@oscc/models/Fragment';
+import { Fragment } from '@oscc/models/Fragment';
 
 @Injectable({
   providedIn: 'root',
@@ -26,9 +26,9 @@ export class FormatterService {
    */
   private convert_italics_encoding(doc: Fragment): Fragment {
     doc.lines.forEach((line: any) => {
-      line.text = line.text.replaceAll('<i>', '$')
-      line.text = line.text.replaceAll('</i>', '$')
-    })
+      line.text = line.text.replaceAll('<i>', '$');
+      line.text = line.text.replaceAll('</i>', '$');
+    });
     return doc;
   }
 

--- a/angular/src/app/playground/services/formatter.service.ts
+++ b/angular/src/app/playground/services/formatter.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 import { environment } from '@src/environments/environment';
 
+import {Fragment} from '@oscc/models/Fragment';
+
 @Injectable({
   providedIn: 'root',
 })
@@ -10,7 +12,23 @@ export class FormatterService {
   public format(doc: any): any {
     if (doc.document_type == environment.fragment) {
       doc = this.convert_whitespace_encoding(doc);
+      doc = this.convert_italics_encoding(doc);
     }
+    return doc;
+  }
+
+  /**
+   * Converts the italics encoding to simple $-signs. These are later removed
+   * by FabricJS, their locations turned into delimiters for cursive text
+   * @param doc (Fragment)
+   * @return Fragment
+   * @author Ycreak
+   */
+  private convert_italics_encoding(doc: Fragment): Fragment {
+    doc.lines.forEach((line: any) => {
+      line.text = line.text.replaceAll('<i>', '$')
+      line.text = line.text.replaceAll('</i>', '$')
+    })
     return doc;
   }
 


### PR DESCRIPTION
Fixes #276
Fixes #199 

We can now add testimonia to the playground. Additonally, we allow fragments to be cursive (needs to be extended to other document types)