### PR TITLE
Bib keys saved in commentary (again)

### DIFF
--- a/angular/src/app/columns/columns.component.ts
+++ b/angular/src/app/columns/columns.component.ts
@@ -187,8 +187,7 @@ export class ColumnsComponent implements OnInit {
     const column_bib_keys: string[] = [];
     // If there are keys, show the bibliography
     column.documents.forEach((doc: any) => {
-      const bib_keys = this.bib.get_keys_from_document(doc);
-      bib_keys.forEach((key: string) => {
+      doc.commentary.bib_keys.forEach((key: string) => {
         column_bib_keys.push(key);
       });
     });

--- a/angular/src/app/columns/columns.service.ts
+++ b/angular/src/app/columns/columns.service.ts
@@ -145,6 +145,9 @@ export class ColumnsService {
       column.original_fragment_order = []; // Clear first
       documents.forEach((doc: any) => {
         column.original_fragment_order.push(doc.name);
+        // Make a list of bib keys per commentary. We do this to keep track of bibliography entries,
+        // as we will overwrite the keys with citations when a commentary is formatted upon loading.
+        doc.commentary.bib_keys = this.bib.get_keys_from_document(doc);
       });
     });
   }

--- a/angular/src/app/commentary/commentary.component.ts
+++ b/angular/src/app/commentary/commentary.component.ts
@@ -116,7 +116,7 @@ export class CommentaryComponent {
    * @author Ycreak
    */
   private create_bibliography(doc: any): string {
-    return this.bib.convert_keys_into_bibliography(this.bib.get_keys_from_commentary(doc.commentary));
+    return this.bib.convert_keys_into_bibliography(doc.commentary.bib_keys);
   }
 
   /**


### PR DESCRIPTION
Once, we saved bib keys to the commentary object. For some reason, this approach was lost (probably because of the bib service) and I forget. It is back now! Huzzah!