### PR TITLE
Make update zotero cache more robust

### DIFF
--- a/flask/endpoints/zotero.py
+++ b/flask/endpoints/zotero.py
@@ -49,9 +49,12 @@ class Zotero:
 
     def _update_cached_bibliography(self) -> None:
         """
-        Updates the cached bibliography by matching the latest version in cache to the latest
+        Removes entries from cache that have been removed from Zotero. Also updates the 
+        cached bibliography by matching the latest version in cache to the latest
         version known on the server. Will update all items that are new or updated.
         """        
+        self._remove_deleted_entries_from_cache()
+
         latest_cached_version = self.get_latest_cached_version()
         # Now get a key list of all items that have changes since the last known change to the cache
         keys_dictionary = self.zotero_api.item_versions(since=latest_cached_version)
@@ -64,23 +67,29 @@ class Zotero:
             # Retrieve the zotero item bib blob 
             self.zotero_api.add_parameters(content='bib')
             bib_item['citation'] = self.zotero_api.item(key)[0]
+            # Delete the old key from the bibliography and append the updated one
             self.bibliography = [d for d in self.bibliography if d['key'] != key]
             self.bibliography.append(bib_item)
+            # Zotero really likes to stop working after a few api calls. We therefore save the cache
+            # file after every update. It is quite wasteful, but at least we wont lose any progress
+            util.write_json(self.bibliography, self.cache_file)
 
-        # Delete from the cache those entries that are deleted from Zotero
-        cached_keys = [x['key'] for x in self.bibliography]
-        online_keys = list(self.zotero_api.item_versions().keys())
+    def _remove_deleted_entries_from_cache(self) -> None:
+        """
+        Deletes items from the cache that have been deleted in Zotero
+        """
+        cached_keys: list = [x['key'] for x in self.bibliography]
+        online_keys: list = list(self.zotero_api.item_versions().keys())
 
-        deleted_keys = list(set(cached_keys) - set(online_keys))
+        deleted_keys: list = list(set(cached_keys) - set(online_keys))
 
         if len(deleted_keys) > 0:
-            print(deleted_keys)
             for key in deleted_keys:
-                print('Removing deleted item:', key)
-                self.bibliography = [d for d in self.bibliography if d['key'] != key]
-
+                self.bibliography: list = [d for d in self.bibliography if d['key'] != key]
+        
         util.write_json(self.bibliography, self.cache_file)
-    
+
+
     def _update_citations(self) -> None:
         """
         Dumb function to update citations in sources that do not yet have a citation.


### PR DESCRIPTION
Zotero likes to stop working after five api calls. We now save the cache after each citation update, just to be sure.