### PR TITLE
Return empty list when found no playgrounds

### DIFF
--- a/flask/endpoints/playground.py
+++ b/flask/endpoints/playground.py
@@ -35,7 +35,7 @@ def get_playgrounds_list():
     playground_lst = playgrounds.list(Playground(user=user), sorted=True)
 
     if not playground_lst:
-        return make_response("Not found", 401)
+        return jsonify([]), 200
     
     return jsonify(playground_lst), 200
 


### PR DESCRIPTION
The load playgrounds dialog would hang when no playgrounds were available. The API now returns an empty list if no playgrounds are found. Angular will tell the user of the non-existance of playgrounds.