### PR TITLE
Request includes sandbox and document type

### DIFF
--- a/angular/src/app/dashboard/fragments-dashboard/fragments-dashboard.component.ts
+++ b/angular/src/app/dashboard/fragments-dashboard/fragments-dashboard.component.ts
@@ -359,6 +359,7 @@ export class FragmentsDashboardComponent implements OnInit {
               // When the has been revised, we will load said fragment and fill the fields again
               this.request_documents({
                 document_type: 'fragment',
+                sandbox: this.sandbox.current_sandbox,
                 author: fragment.author,
                 title: fragment.title,
                 editor: fragment.editor,
@@ -398,6 +399,8 @@ export class FragmentsDashboardComponent implements OnInit {
           this.api.post_document(fragment, 'create').subscribe(() => {
             // When the has been created, we will load said fragment and fill the fields again
             this.request_documents({
+              document_type: 'fragment',
+              sandbox: this.sandbox.current_sandbox,
               author: fragment.author,
               title: fragment.title,
               editor: fragment.editor,

--- a/angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.ts
+++ b/angular/src/app/dashboard/testimonia-dashboard/testimonia-dashboard.component.ts
@@ -96,6 +96,7 @@ export class TestimoniaDashboardComponent {
           this.api.post_document(form, 'create').subscribe(() => {
             this.request({
               document_type: 'testimonium',
+              sandbox: this.sandbox.current_sandbox,
               author: form.author,
               name: form.name,
             });
@@ -120,6 +121,7 @@ export class TestimoniaDashboardComponent {
             this.reset_form();
             this.request({
               document_type: 'testimonium',
+              sandbox: this.sandbox.current_sandbox,
               author: form.author,
               name: form.name,
             });


### PR DESCRIPTION
When creating a document, we request the created document to continue working easily. It does now need a document type and a sandbox as meta data, so I added that.

Closes #331 