### PR TITLE
Sajvanwijk/issue338

### DIFF
--- a/angular/src/app/columns/columns.component.html
+++ b/angular/src/app/columns/columns.component.html
@@ -15,11 +15,12 @@
             document_type: $event.document_type,
             author: $event.author,
             title: $event.title,
-            editor: $event.editor
+            editor: $event.editor,
           },
           column_to_display.column_id
         );
-        column_to_display.column_name = $event.author + '-' + $event.title + '-' + $event.editor
+        column_to_display.column_name = $event.author + '-' + $event.title + '-' + $event.editor;
+        this.columns.set_edited_flag_false(column_to_display.column_id)
       ">
     </app-latin-tragic-fragment-filter>
 
@@ -103,7 +104,7 @@
         "
         cdkDrag
         [cdkDragDisabled]="this.settings.fragments.dragging_disabled"
-        (cdkDragDropped)="this.columns.set_edited_flag($event)"
+        (cdkDragDropped)="this.columns.set_edited_flag_true($event.container.id, $event.previousContainer.id)"
         [attr.id]="fragment.fragment_id"
         [style.background-color]="
           this.generate_document_gradient_background_color(

--- a/angular/src/app/columns/columns.component.html
+++ b/angular/src/app/columns/columns.component.html
@@ -15,7 +15,7 @@
             document_type: $event.document_type,
             author: $event.author,
             title: $event.title,
-            editor: $event.editor,
+            editor: $event.editor
           },
           column_to_display.column_id
         );

--- a/angular/src/app/columns/columns.component.ts
+++ b/angular/src/app/columns/columns.component.ts
@@ -90,6 +90,8 @@ export class ColumnsComponent implements OnInit {
           // New API update will allow us to request a list of filters
           result.filters.forEach((filter: any) => {
             this.columns.request(filter, column_id, true);
+            // Also reset the 'edited/altered' status for these columns to false
+            this.columns.set_edited_flag_false(column_id);
           });
         }
       },

--- a/angular/src/app/columns/columns.service.ts
+++ b/angular/src/app/columns/columns.service.ts
@@ -198,18 +198,33 @@ export class ColumnsService {
   /**
    * We keep track of dragging and dropping within or between columns. If an edit occurs,
    * we set the corresponding document_column boolean 'edited' to true.
-   * @param event containing the column identifiers of those that are edited
+   * @param column1 the first edited column
+   * @param column2 the second edited column
    * @author Ycreak
-   * @TODO: what type is 'event'? CdkDragDrop<string[]> does not allow reading.
    */
-  public set_edited_flag(event: any): void {
+  public set_edited_flag_true(column1: number, column2: number): void {
     // First, find the corresponding columns in this.list using the column_id that is used
     // in this.connected used by cdkDrag (and encoded in event)
-    const edited_column_1 = this.list.find((i) => i.column_id === Number(event.container.id));
-    const edited_column_2 = this.list.find((i) => i.column_id === Number(event.previousContainer.id));
+    const edited_column_1 = this.list.find((i) => i.column_id === Number(column1));
+    const edited_column_2 = this.list.find((i) => i.column_id === Number(column2));
     // Next, set the edited flag to true.
     edited_column_1.edited = true;
     edited_column_2.edited = true;
+  }
+
+  /**
+   * Related to the method above; when loading a column's data freshly from memory, the 'edited' flag will be set to false.
+   * (After all the laoded data has not been edited yet by the user.)
+   * @param column_id identifier of the column that has been refreshed.
+   * @author sajvanwijk
+   */
+  public set_edited_flag_false(column_id: number): void {
+    // First, find the corresponding columns in this.list using the column_id that is used
+    // in this.connected used by cdkDrag (and encoded in event)
+    console.log('test');
+    const column = this.list.find((i) => i.column_id === column_id);
+    // Next, set the edited flag to false.
+    column.edited = false;
   }
 
   /**

--- a/angular/src/app/columns/columns.service.ts
+++ b/angular/src/app/columns/columns.service.ts
@@ -214,14 +214,13 @@ export class ColumnsService {
 
   /**
    * Related to the method above; when loading a column's data freshly from memory, the 'edited' flag will be set to false.
-   * (After all the laoded data has not been edited yet by the user.)
+   * (After all the loaded data has not been edited yet by the user.)
    * @param column_id identifier of the column that has been refreshed.
    * @author sajvanwijk
    */
   public set_edited_flag_false(column_id: number): void {
     // First, find the corresponding columns in this.list using the column_id that is used
     // in this.connected used by cdkDrag (and encoded in event)
-    console.log('test');
     const column = this.list.find((i) => i.column_id === column_id);
     // Next, set the edited flag to false.
     column.edited = false;


### PR DESCRIPTION
Fixes #338

Fixed! I set the altered label to reset after loading text via the normal text selector as well as the advanced text selector.

Now we have two methods in the html: one for setting the edited flag to true and one for setting it to false. Both take numbers now as their arguments, which I thought was a bit more universally applicable than having this CdkDragDropEvent thing as the input argument.