### PR TITLE
Add source text to the context field

### DIFF
--- a/angular/src/app/api.service.ts
+++ b/angular/src/app/api.service.ts
@@ -183,7 +183,7 @@ export class ApiService {
   }
 
   /**
-   * Asks Flask to test the Zotero bibliography. 
+   * Asks Flask to test the Zotero bibliography.
    * @param key (object)
    * @author Ycreak
    */

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -74,6 +74,7 @@ import { LinnaeusComponent } from './components/linnaeus/linnaeus.component';
 import { DocumentFilterComponent } from './filters/document-filter/document-filter.component';
 import { UsersComponent } from './dashboard/users/users.component';
 import { TestimoniaComponent } from './columns/testimonia/testimonia.component';
+import { ContextComponent } from './columns/context/context.component';
 import { FragmentComponent } from './columns/fragment/fragment.component';
 import { OnCopyDirective } from './directives/on-copy.directive';
 import { TestimoniaDashboardComponent } from './dashboard/testimonia-dashboard/testimonia-dashboard.component';
@@ -125,6 +126,7 @@ const appRoutes: Routes = [
     DocumentFilterComponent,
     UsersComponent,
     TestimoniaComponent,
+    ContextComponent,
     FragmentComponent,
     OnCopyDirective,
     TestimoniaDashboardComponent,

--- a/angular/src/app/columns/columns.component.html
+++ b/angular/src/app/columns/columns.component.html
@@ -118,6 +118,9 @@
         <div *ngIf="fragment.document_type === 'fragment'">
           <app-fragment [fragment]="fragment" [translated]="given_column.translated"> </app-fragment>
         </div>
+        <div *ngIf="fragment.document_type === 'context'">
+          <app-context [context]="fragment"> </app-context>
+        </div>
       </div>
     </div>
   </div>
@@ -127,6 +130,7 @@
 <mat-menu #rightMenu="matMenu">
   <ng-template matMenuContent let-item="item">
     <button (click)="this.copy_document_content(matMenuTrigger.menuData.document)" mat-menu-item>Copy text</button>
+    <button (click)="this.show_broader_context(matMenuTrigger.menuData.document)" mat-menu-item>Broader context</button>
     <button (click)="this.show_linked_documents(matMenuTrigger.menuData.document)" mat-menu-item>
       Linked documents
     </button>

--- a/angular/src/app/columns/columns.component.ts
+++ b/angular/src/app/columns/columns.component.ts
@@ -123,6 +123,27 @@ export class ColumnsComponent implements OnInit {
   }
 
   /**
+   * Shows broader context of the selected fragment based on the text fields of its commentary.context.
+   * @param given_document with possible broader context
+   */
+  protected show_broader_context(given_document: any): void {
+    console.log(given_document);
+    if (given_document.commentary.fields.context.length > 0) {
+      const column_id = this.columns.add();
+      const column = this.columns.find(column_id);
+      given_document.commentary.fields.context.forEach((context: any) => {
+        if (context.text != '') {
+          // Add a document type so the frontend will know how to handle this context
+          context.document_type = 'context';
+          column.documents.push(context);
+        }
+      });
+    } else {
+      this.utility.open_snackbar('No broader context found');
+    }
+  }
+
+  /**
    * Retrieves linked fragments from server and shows them in a new column
    * @author Ycreak
    */

--- a/angular/src/app/columns/columns.component.ts
+++ b/angular/src/app/columns/columns.component.ts
@@ -127,8 +127,11 @@ export class ColumnsComponent implements OnInit {
    * @param given_document with possible broader context
    */
   protected show_broader_context(given_document: any): void {
-    console.log(given_document);
-    if (given_document.commentary.fields.context.length > 0) {
+    if (
+      // First check if the given document has broader context.
+      given_document.commentary.fields.context.length > 0 &&
+      given_document.commentary.fields.context.some((item) => item.text && item.text.trim() !== '')
+    ) {
       const column_id = this.columns.add();
       const column = this.columns.find(column_id);
       given_document.commentary.fields.context.forEach((context: any) => {

--- a/angular/src/app/columns/context/context.component.html
+++ b/angular/src/app/columns/context/context.component.html
@@ -1,0 +1,4 @@
+<div *ngIf="this.settings.fragments.show_headers">
+  <b>{{ this.context.author }} </b> <i>{{ this.context.location }}</i> &nbsp;
+</div>
+<p [innerHTML]="this.context.text"></p>

--- a/angular/src/app/columns/context/context.component.scss
+++ b/angular/src/app/columns/context/context.component.scss
@@ -1,0 +1,1 @@
+@import url("../columns.component.scss");

--- a/angular/src/app/columns/context/context.component.spec.ts
+++ b/angular/src/app/columns/context/context.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ContextComponent } from './context.component';
+
+describe('ContextComponent', () => {
+  let component: ContextComponent;
+  let fixture: ComponentFixture<ContextComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ContextComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ContextComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular/src/app/columns/context/context.component.ts
+++ b/angular/src/app/columns/context/context.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { Input } from '@angular/core';
+
+import { SettingsService } from '@oscc/services/settings.service';
+
+import { Context } from '@oscc/models/Context';
+
+@Component({
+  selector: 'app-context',
+  templateUrl: './context.component.html',
+  styleUrls: ['./context.component.scss'],
+})
+export class ContextComponent {
+  @Input() context: Context;
+
+  constructor(protected settings: SettingsService) {}
+}

--- a/angular/src/app/commentary/commentary.component.html
+++ b/angular/src/app/commentary/commentary.component.html
@@ -92,7 +92,7 @@
         </mat-expansion-panel-header>
         <div class="mat-expansion-panel-content">
           <div class="mat-expansion-panel-body">
-            <app-expandable-text [content]="current_context.text"></app-expandable-text>
+            <app-expandable-text [content]="current_context.commentary"></app-expandable-text>
           </div>
         </div>
       </mat-expansion-panel>

--- a/angular/src/app/dashboard/dashboard.component.html
+++ b/angular/src/app/dashboard/dashboard.component.html
@@ -16,9 +16,7 @@
   </span>
   <span class="spacer"></span>
   <!-- <button mat-button class="btn" (click)="this.api.request_authors2(this.selected_fragment_data)">RELOAD AUTHORS</button> -->
-  <button mat-stroked-button class="navbar button-margin" (click)="this.request_bibliography_test()">
-    CITATIONS 
-  </button>
+  <button mat-stroked-button class="navbar button-margin" (click)="this.request_bibliography_test()">CITATIONS</button>
   <button mat-stroked-button class="navbar button-margin" (click)="this.request_bibliography_resync()">
     SYNC BIBLIOGRAPHY
   </button>

--- a/angular/src/app/dashboard/fragments-dashboard/fragments-dashboard.component.html
+++ b/angular/src/app/dashboard/fragments-dashboard/fragments-dashboard.component.html
@@ -253,7 +253,7 @@
         <div class="div-padding-lg"></div>
 
         <div formArrayName="context" *ngFor="let item of fragment_form.get('context')['controls']; let i = index">
-          <div [formGroupName]="i">
+          <div class="context-item" [formGroupName]="i">
             <mat-form-field class="input-form-small">
               <mat-label>Context author name</mat-label>
               <input matInput type="text" formControlName="author" />
@@ -271,7 +271,12 @@
               <textarea matInput type="text" formControlName="text"></textarea>
             </mat-form-field>
 
-            <button mat-button (click)="request_wysiwyg_dialog('context', i)">Rich editor</button>
+            <mat-form-field class="input-form-half">
+              <mat-label>Context commentary</mat-label>
+              <textarea matInput type="text" formControlName="commentary"></textarea>
+            </mat-form-field>
+
+            <button mat-button (click)="request_wysiwyg_dialog('context', i)">Edit context commentary</button>
             <button mat-button (click)="remove_form_item_from_form_array('fragment_form', 'context', i)">
               Delete this context
             </button>

--- a/angular/src/app/dashboard/fragments-dashboard/fragments-dashboard.component.scss
+++ b/angular/src/app/dashboard/fragments-dashboard/fragments-dashboard.component.scss
@@ -1,1 +1,8 @@
 @import url("../dashboard.component.scss");
+
+.context-item {
+  border: 1px solid #ccc;
+  padding: 16px;
+  margin-bottom: 16px;
+  border-radius: 4px;
+}

--- a/angular/src/app/dashboard/fragments-dashboard/fragments-dashboard.component.ts
+++ b/angular/src/app/dashboard/fragments-dashboard/fragments-dashboard.component.ts
@@ -119,14 +119,14 @@ export class FragmentsDashboardComponent implements OnInit {
   protected request_wysiwyg_dialog(field: string, index = 0): void {
     if (field == 'context') {
       // For the context, retrieve the context text field from the fragment form and pass that to the dialog
-      const form_array_field = this.fragment_form.value.context[index].text;
+      const form_array_field = this.fragment_form.value.context[index].commentary;
       this.dialog.open_wysiwyg_dialog(form_array_field).subscribe((result) => {
         if (result) {
           // Result will only be provided when the user has acceped the changes
           // Now update the correct field. This is done by getting the FormArray and patching the correct
           // FormGroup within this array. This is to ensure dynamic updating on the frontend
           const context_array = this.fragment_form.controls['context'] as FormArray;
-          context_array.controls[index].patchValue({ ['text']: result });
+          context_array.controls[index].patchValue({ ['commentary']: result });
         }
       });
     } else {
@@ -189,7 +189,8 @@ export class FragmentsDashboardComponent implements OnInit {
       this.push_fragment_context_to_fragment_form(
         fragment.commentary.fields.context[i].author,
         fragment.commentary.fields.context[i].location,
-        fragment.commentary.fields.context[i].text
+        fragment.commentary.fields.context[i].text,
+        fragment.commentary.fields.context[i].commentary
       );
     }
     // Fill the fragment lines array
@@ -260,12 +261,18 @@ export class FragmentsDashboardComponent implements OnInit {
    * @param text text of the actual context in which the fragment appears
    * @author Ycreak
    */
-  protected push_fragment_context_to_fragment_form(_author: string, _location: string, _text: string): void {
+  protected push_fragment_context_to_fragment_form(
+    _author: string,
+    _location: string,
+    _text: string,
+    _commentary: string
+  ): void {
     // First, create a form group to represent a context
     const new_context = new FormGroup({
       author: new FormControl(_author),
       location: new FormControl(_location),
       text: new FormControl(_text),
+      commentary: new FormControl(_commentary),
     });
     // Next, push the created form group to the context FormArray
     const fragment_context_array = this.fragment_form.get('context') as FormArray;

--- a/angular/src/app/models/Context.ts
+++ b/angular/src/app/models/Context.ts
@@ -2,7 +2,8 @@ export class Context {
   constructor(
     public author: string,
     public location: string,
-    public text: string
+    public text: string,
+    public commentary: string
   ) {
     // this.id = id;
     // this.fragment = fragmentID;

--- a/angular/src/app/overview/overview.component.html
+++ b/angular/src/app/overview/overview.component.html
@@ -61,7 +61,7 @@
   <a href="https://github.com/Ycreak/OpensourceClassicCommentary/" target="_blank" mat-menu-item>Documentation</a>
   <button (click)="this.settings.open_settings()" mat-menu-item>Settings</button>
   <button (click)="this.dialog.open_about_dialog()" mat-menu-item>About</button>
-  <div mat-menu-item>V25.03.10</div>
+  <div mat-menu-item>V25.06.29</div>
   <div class="social-media-icons-div">
     <a href="https://bsky.app/profile/oscc753.bsky.social" target="_blank"
       ><mat-icon class="social-media-icon" svgIcon="bluesky" title="Link to our Bluesky page"></mat-icon

--- a/flask/migrations/context_commentary.py
+++ b/flask/migrations/context_commentary.py
@@ -1,0 +1,40 @@
+"""
+This migration migrates the context.text to context.commentary, so that we can use the text field for 
+broad context information.
+"""
+import couchdb
+
+class Migration:
+    def __init__(self):
+        self.couch = couchdb.Server('http://admin:secret@localhost:5984/')
+        self.db = self.couch['documents']
+
+    def change_db(self, db: str) -> None:
+        self.db = self.couch[db]
+
+    def print_all_documents(self, db):
+        for id in db:
+            doc = db[id]
+            print(doc)    
+
+    def migrate_context(self) -> None:
+        """
+        Adds the sandbox property to all documents in the current database
+        """
+        for id in self.db:
+            doc = self.db[id]
+
+            if doc['document_type'] == 'fragment':
+                if 'context' in doc and doc['context']:
+                    for context in doc['context']:
+                        context['commentary'] = context['text']
+                        context['text'] = '' 
+                    print(doc['_id'])
+                    # print(doc['context'])
+                    doc_id, doc_rev = self.db.save(doc)
+    
+if __name__ == "__main__":
+    migration = Migration()
+
+    migration.change_db('documents')
+    migration.migrate_context()


### PR DESCRIPTION
This PR adds the possibility to retrieve a broader context for the current fragment by right clicking it and selecting "broader context". This allows the user to see the fragment in the wild, by all its citing authors!