### PR TITLE
Added warning for using chevrons

### DIFF
--- a/angular/src/app/dialogs/wysiwyg/wysiwyg-dialog.component.html
+++ b/angular/src/app/dialogs/wysiwyg/wysiwyg-dialog.component.html
@@ -2,6 +2,10 @@
 The configuration for the editor is given via data.config. When accept is clicked, the updated data is returned to the caller
 in plain HTML. -->
 <div mat-dialog-content>
+  <div class="alert alert-info" role="alert">
+    Please do not use the angle brackets (<b>&lt;</b> and <b>&gt;</b>): these will be filtered by the system as HTML
+    notation. Do use the provided brackets: <b>⟨</b> and <b>⟩</b>.
+  </div>
   <quill-editor [(ngModel)]="data.content" (onEditorCreated)="this.editor_instance = $event">
     <div quill-editor-toolbar>
       <!-- Add a bold and italics buttons -->


### PR DESCRIPTION
Some students used chevrons in their editions, which are being filtered as being html. We add a warning to the rich editor, as this is the simplest thing to do.