### PR TITLE
Fix bibliography glitches

### DIFF
--- a/angular/src/app/columns/columns.component.ts
+++ b/angular/src/app/columns/columns.component.ts
@@ -268,8 +268,7 @@ export class ColumnsComponent implements OnInit {
     const column_bib_keys: string[] = [];
     // If there are keys, show the bibliography
     column.documents.forEach((doc: any) => {
-      const bib_keys = this.bib.get_keys_from_document(doc);
-      bib_keys.forEach((key: string) => {
+      doc.commentary.bib_keys.forEach((key: string) => {
         column_bib_keys.push(key);
       });
     });

--- a/angular/src/app/commentary/commentary.component.ts
+++ b/angular/src/app/commentary/commentary.component.ts
@@ -89,9 +89,11 @@ export class CommentaryComponent {
       this.linked_commentaries = [];
       // Add additional formatting to the commentary
       this.commentary.do_on_fields(this.string_formatter.convert_custom_tag_to_html);
-      // Create a bibliography for the document
-      this.commentary.bibliography = this.create_bibliography(this.document);
-      this.convert_bib_keys_in_commentary();
+      // Construct the bibliography if we did not do that already for the click document.
+      if (this.commentary.bibliography === '') {
+        this.commentary.bibliography = this.create_bibliography(this.document);
+        this.convert_bib_keys_in_commentary();
+      }
     });
   }
 
@@ -132,7 +134,7 @@ export class CommentaryComponent {
    * @author Ycreak
    */
   private create_bibliography(doc: any): string {
-    return this.bib.convert_keys_into_bibliography(this.bib.get_keys_from_commentary(doc.commentary));
+    return this.bib.convert_keys_into_bibliography(doc.commentary.bib_keys);
   }
 
   /**

--- a/angular/src/app/services/bibliography.service.ts
+++ b/angular/src/app/services/bibliography.service.ts
@@ -95,7 +95,12 @@ export class BibliographyService {
   public convert_bib_key_into_citation(bib_key: string): string {
     const bib_item = this.bibliography.find((o) => o.key === bib_key);
     //Add the item to the bibliography for easy printing in an expansion panel
-    return bib_item.citation;
+    if (bib_item) {
+      return bib_item.citation;
+    } else {
+      console.error(`bib_key ${bib_key} could not be found in the bibliography.`);
+      return '';
+    }
   }
 
   /**


### PR DESCRIPTION
This PR fixes the glitches with showing the bibliography we've been having. Apparently, I already fixed this halfway using bib keys in the commentary objects, but never fully implemented it. Here you go, now it should work better!

It will also log errors when a key is called by a fragment, that does not appear in the zotero bibliography.