### PR TITLE
Playground hamburger menu and help text

### DIFF
--- a/angular/src/app/dialogs/custom-dialog/custom-dialog.component.html
+++ b/angular/src/app/dialogs/custom-dialog/custom-dialog.component.html
@@ -1,4 +1,4 @@
 <!-- This dialog simply shows whatever input has been provided -->
 <div mat-dialog-content>
-  <div [innerHTML]="data.content | safeHtml"></div>
+  <div class="custom-dialog-text" [innerHTML]="data.content | safeHtml"></div>
 </div>

--- a/angular/src/app/dialogs/custom-dialog/custom-dialog.component.scss
+++ b/angular/src/app/dialogs/custom-dialog/custom-dialog.component.scss
@@ -1,0 +1,3 @@
+div.custom-dialog-text {
+  padding: 10px;
+}

--- a/angular/src/app/dialogs/custom-dialog/custom-dialog.component.ts
+++ b/angular/src/app/dialogs/custom-dialog/custom-dialog.component.ts
@@ -12,7 +12,7 @@ import { SafeHtmlPipe } from '@oscc/pipes/safeHtml.pipe';
   standalone: true,
   imports: [SafeHtmlPipe],
   templateUrl: './custom-dialog.component.html',
-  styleUrls: ['../dialogs.scss'],
+  styleUrls: ['../dialogs.scss', './custom-dialog.component.scss'],
 })
 export class CustomDialogComponent {
   constructor(

--- a/angular/src/app/playground/playground.component.html
+++ b/angular/src/app/playground/playground.component.html
@@ -23,6 +23,13 @@
     </div>
 
     <div id="playground-main-toolbar" class="playground-toolbar">
+      <!-- Hamburger menu -->
+      <div id="playground-hamburger-menu" class="playground-tool-group">
+        <button id="playground-hamburger-menu-button" mat-stroked-button class="navbar" [matMenuTriggerFor]="menu">
+          <mat-icon fontIcon="menu"></mat-icon>
+          <!-- <span *ngIf="this.window_watcher.size > 850">MENU</span> -->
+        </button>
+      </div>
       <div id="playground-document-tools" class="playground-tool-group">
         <app-latin-tragic-fragment-filter
           [button_title]="''"
@@ -121,3 +128,48 @@
     </div>
   </div>
 </div>
+<!-- Hamburger menu content -->
+<mat-menu #menu="matMenu">
+  <button mat-menu-item (click)="this.load_playground()">
+    <div class="hamburger-menu-item-icon-wrapper">
+      <img
+        id="playground_load_btn"
+        class="playground-icon"
+        src="assets\icons\ByteDanceIconPark\9068981_folder_open_icon.png" />
+    </div>
+    Load Playground
+  </button>
+  <button mat-menu-item (click)="this.save_playground()">
+    <div class="hamburger-menu-item-icon-wrapper">
+      <img
+        id="playground_save_btn"
+        class="playground-icon"
+        src="assets\icons\ByteDanceIconPark\9070374_hard_disk_one_icon.png" />
+    </div>
+    Save Playground
+  </button>
+  <button mat-menu-item (click)="this.create_live_room()">
+    <div class="hamburger-menu-item-icon-wrapper">
+      <img
+        *ngIf="this.auth_service.is_logged_in"
+        id="playground_share_btn"
+        class="playground-icon"
+        src="assets\icons\ByteDanceIconPark\9071373_people_plus_one_icon.png" />
+    </div>
+    Create Shared Session
+  </button>
+  <button mat-menu-item (click)="this.join_playground()">
+    <div class="hamburger-menu-item-icon-wrapper">
+      <img
+        *ngIf="this.auth_service.is_logged_in"
+        id="playground_join_btn"
+        class="playground-icon"
+        src="assets\icons\ByteDanceIconPark\9071420_people_download_icon.png" />
+    </div>
+    Join Shared Session
+  </button>
+  <button mat-menu-item>
+    <div class="hamburger-menu-item-icon-wrapper"></div>
+    Settings
+  </button>
+</mat-menu>

--- a/angular/src/app/playground/playground.component.html
+++ b/angular/src/app/playground/playground.component.html
@@ -27,7 +27,6 @@
       <div id="playground-hamburger-menu" class="playground-tool-group">
         <button id="playground-hamburger-menu-button" mat-stroked-button class="navbar" [matMenuTriggerFor]="menu">
           <mat-icon fontIcon="menu"></mat-icon>
-          <!-- <span *ngIf="this.window_watcher.size > 850">MENU</span> -->
         </button>
       </div>
       <div id="playground-document-tools" class="playground-tool-group">
@@ -125,13 +124,18 @@
           src="assets\icons\ByteDanceIconPark\9071420_people_download_icon.png"
           (click)="this.join_playground()" />
       </div>
+      <div id="playground-help-menu" class="playground-tool-group">
+        <button id="playground-help-menu-button" mat-stroked-button class="navbar" [matMenuTriggerFor]="helpmenu">
+          <mat-icon fontIcon="question_mark"></mat-icon>
+        </button>
+      </div>
     </div>
   </div>
 </div>
 <!-- Hamburger menu content -->
 <mat-menu #menu="matMenu">
   <button mat-menu-item (click)="this.load_playground()">
-    <div class="hamburger-menu-item-icon-wrapper">
+    <div class="menu-item-icon-wrapper">
       <img
         id="playground_load_btn"
         class="playground-icon"
@@ -140,7 +144,7 @@
     Load Playground
   </button>
   <button mat-menu-item (click)="this.save_playground()">
-    <div class="hamburger-menu-item-icon-wrapper">
+    <div class="menu-item-icon-wrapper">
       <img
         id="playground_save_btn"
         class="playground-icon"
@@ -149,7 +153,7 @@
     Save Playground
   </button>
   <button mat-menu-item (click)="this.create_live_room()">
-    <div class="hamburger-menu-item-icon-wrapper">
+    <div class="menu-item-icon-wrapper">
       <img
         *ngIf="this.auth_service.is_logged_in"
         id="playground_share_btn"
@@ -159,7 +163,7 @@
     Create Shared Session
   </button>
   <button mat-menu-item (click)="this.join_playground()">
-    <div class="hamburger-menu-item-icon-wrapper">
+    <div class="menu-item-icon-wrapper">
       <img
         *ngIf="this.auth_service.is_logged_in"
         id="playground_join_btn"
@@ -169,7 +173,12 @@
     Join Shared Session
   </button>
   <button mat-menu-item>
-    <div class="hamburger-menu-item-icon-wrapper"></div>
+    <div class="menu-item-icon-wrapper"></div>
     Settings
   </button>
+</mat-menu>
+
+<mat-menu #helpmenu="matMenu">
+  <button mat-menu-item (click)="this.show_helpmenu('a')">What is the playground</button>
+  <button mat-menu-item (click)="this.show_helpmenu('b')">How to use the playground</button>
 </mat-menu>

--- a/angular/src/app/playground/playground.component.scss
+++ b/angular/src/app/playground/playground.component.scss
@@ -11,13 +11,10 @@
 }
 
 #playground-hamburger-menu {
-  width: 100%;
+  display: inline-flex;
   position: absolute;
-  display: flex;
+  left: 16px;
   flex-wrap: nowrap;
-  place-content: left;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 @property --hamburgerMenuColor {
@@ -27,7 +24,6 @@
 }
 
 #playground-hamburger-menu-button {
-  // background-color: #555a77;
   border-radius: 4px;
   border-color: transparent;
   transition: --hamburgerMenuColor 0.2s;
@@ -41,12 +37,44 @@
   --hamburgerMenuColor: rgba(159, 161, 254, 0.7);
 }
 
-.hamburger-menu-item-icon-wrapper {
+.menu-item-icon-wrapper {
   display: inline-block;
   width: 50px;
   position: relative;
   top: 7px;
   left: -7px;
+}
+
+#playground-help-menu {
+  display: inline-flex;
+  position: absolute;
+  // right: 16px;
+  right: 4px;
+  top: -16px;
+  flex-wrap: nowrap;
+}
+
+@property --helpMenuColor {
+  syntax: "<color>";
+  initial-value: rgba(160, 162, 168, 0.116);
+  inherits: false;
+}
+
+#playground-help-menu-button {
+  // border-radius: 4px;
+  border-radius: 0px 0px 0px 50px;
+  border-color: transparent;
+  transition: --helpMenuColor 0.2s;
+  transition-timing-function: cubic-bezier(0.65, 0.05, 0.18, 1.09);
+  background: radial-gradient(circle at center, rgba(150, 150, 189, 0.288) 0%, var(--helpMenuColor) 70%);
+  width: 32px;
+  justify-content: center;
+  padding-left: 5px;
+  padding-top: 5px;
+}
+
+#playground-help-menu-button:hover {
+  --helpMenuColor: rgba(159, 161, 254, 0.7);
 }
 
 .note {
@@ -200,14 +228,11 @@ hr.playground-divider-top {
 }
 .playground-toolbar {
   width: 100%;
-  left: 1rem;
   top: 1rem;
   position: absolute;
   display: flex;
   flex-wrap: nowrap;
   place-content: center;
-  margin-left: auto;
-  margin-right: auto;
 }
 .playground-tool-group {
   display: inline-flex;

--- a/angular/src/app/playground/playground.component.scss
+++ b/angular/src/app/playground/playground.component.scss
@@ -1,6 +1,54 @@
 /* Playground related CSS */
 @use "../_mixins.scss" as *;
 
+#playground {
+  background-color: white; // This is specifically needed in fullscreen mode.
+}
+
+#playground-canvas {
+  height: 85vh !important; // Sets the height of the canvas in relation to the user's viewport.
+  //TODO make this more elegant for example by having the canvas inherit height from its container.
+}
+
+#playground-hamburger-menu {
+  width: 100%;
+  position: absolute;
+  display: flex;
+  flex-wrap: nowrap;
+  place-content: left;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@property --hamburgerMenuColor {
+  syntax: "<color>";
+  initial-value: rgba(159, 161, 254, 0.31);
+  inherits: false;
+}
+
+#playground-hamburger-menu-button {
+  // background-color: #555a77;
+  border-radius: 4px;
+  border-color: transparent;
+  transition: --hamburgerMenuColor 0.2s;
+  transition-timing-function: cubic-bezier(0.65, 0.05, 0.18, 1.09);
+  background: radial-gradient(circle at center, rgba(159, 161, 254, 0.7) 0%, var(--hamburgerMenuColor) 100%);
+  width: 32px;
+  justify-content: center;
+}
+
+#playground-hamburger-menu-button:hover {
+  --hamburgerMenuColor: rgba(159, 161, 254, 0.7);
+}
+
+.hamburger-menu-item-icon-wrapper {
+  display: inline-block;
+  width: 50px;
+  position: relative;
+  top: 7px;
+  left: -7px;
+}
+
 .note {
   // width: auto;
   // height: auto;

--- a/angular/src/app/playground/playground.component.ts
+++ b/angular/src/app/playground/playground.component.ts
@@ -409,4 +409,37 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
     this.fabric.set_event_handlers();
     this.fabric.init();
   }
+
+  /**
+   * Shows the help menu for the playground
+   * @author sajvanwijk
+   */
+  protected show_helpmenu(helpmenuoption: string): void {
+    let helptext;
+    if (helpmenuoption == 'a') {
+      helptext = `<div><b>This is the playground</b><br><br>
+      This is a place to take fragments and move them around in a freeform way, as to gain new insights. 
+      It is also possible to add notes where you can place your thoughts.
+      <br><br>
+      You can also add other users to your playground in order to collaborate together! This way you will
+      both be able to work on the same fragments and to share insights and connections.
+      </div>`;
+    }
+    if (helpmenuoption == 'b') {
+      helptext = `<div>
+      FIXME See how we can best add icons/images here for additional clarity.<br><br>
+
+      <b>Loading fragments</b><br>
+      Lorem ipsum dolor sit amet 
+      <br><br>
+      <b>Drawing on the playground</b><br><br>
+      <b>Undo/Redo</b><br><br>
+      <b>Saving your playground</b><br><br>
+      <b>Loading a saved playground</b><br><br>
+      <b>Sharing a playground session</b><br><br>
+      <b>Joining a playground session</b><br><br>
+      </div>`;
+    }
+    this.dialog.open_custom_dialog(helptext);
+  }
 }

--- a/angular/src/app/playground/playground.component.ts
+++ b/angular/src/app/playground/playground.component.ts
@@ -66,7 +66,7 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
     }
   }
   // Listener for window resize evenets
-  @HostListener('window:resize', ['$event'])
+  @HostListener('window:resize')
   onResize() {
     // If we resize the window, we want the canvas to resize as well
     this.fabric.resize();

--- a/angular/src/app/playground/playground.component.ts
+++ b/angular/src/app/playground/playground.component.ts
@@ -20,6 +20,7 @@ import { AuthService } from '@oscc/auth/auth.service';
 import { CommentaryService } from '@oscc/commentary/commentary.service';
 import { UtilityService } from '@oscc/utility.service';
 import { FabricService } from './services/fabric.service';
+import { WindowSizeWatcherService } from '@oscc/services/window-watcher.service';
 
 import { FormatterService } from './services/formatter.service';
 
@@ -40,13 +41,14 @@ import { LatinTragicFragmentFilterComponent } from '../filters/latin-tragic-frag
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { NgIf } from '@angular/common';
+import { MatMenuModule } from '@angular/material/menu';
 
 @Component({
   selector: 'app-playground',
   templateUrl: './playground.component.html',
   styleUrls: ['./playground.component.scss'],
   standalone: true,
-  imports: [NgIf, MatProgressBarModule, MatIconModule, LatinTragicFragmentFilterComponent],
+  imports: [NgIf, MatProgressBarModule, MatIconModule, LatinTragicFragmentFilterComponent, MatMenuModule],
 })
 export class PlaygroundComponent implements OnInit, OnDestroy {
   @Output() document_clicked = new EventEmitter<Fragment>();
@@ -90,12 +92,16 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
     protected websockets: WebsocketsService,
     private commentary: CommentaryService,
     private formatter: FormatterService,
-    private mat_dialog: MatDialog
+    private mat_dialog: MatDialog,
+    protected window_watcher: WindowSizeWatcherService
   ) {}
 
   ngOnInit(): void {
     this.init_playground();
     //this.request_documents({ document_type: 'fragment', author: 'Karel' });
+
+    // Create the window watcher for checking viewport size
+    this.window_watcher.init(window.innerWidth);
   }
 
   ngOnDestroy() {
@@ -104,6 +110,10 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
     }
     // Close the websocket
     this.disconnect_from_websocket();
+
+    if (this.window_watcher.subscription$) {
+      this.window_watcher.subscription$.unsubscribe();
+    }
   }
 
   /**

--- a/angular/src/app/services/dialog.service.ts
+++ b/angular/src/app/services/dialog.service.ts
@@ -110,7 +110,6 @@ export class DialogService {
   public open_custom_dialog(content: any): void {
     this.dialog.open(CustomDialogComponent, {
       width: '90%',
-      height: '75%',
       data: {
         content: content,
       },


### PR DESCRIPTION
Here is the POC for the new playground menu and helptext system. Todo is yet to populate the menu with buttons and to populate the helptext menu with helpful text. 

- [ ] Move playground buttons to the new hamburger menu
- [ ] Write helptexts for the playground

Closes #240 
Closes #275 