### PR TITLE
Merge fullscreen functionality for the Playground

### DIFF
--- a/angular/src/app/overview/overview.component.html
+++ b/angular/src/app/overview/overview.component.html
@@ -107,7 +107,7 @@
     </mat-drawer>
 
     <!-- Bottom Drawer (Playground) -->
-    <mat-drawer #bottomDrawer mode="over" position="bottom" [opened]="playground_enabled">
+    <mat-drawer id="playground-drawer" #bottomDrawer mode="over" position="bottom" [opened]="playground_enabled">
       <!--<app-playground (clicked_document)="this.clicked_document = $event"></app-playground>-->
       <app-playground></app-playground>
     </mat-drawer>

--- a/angular/src/app/playground/playground.component.html
+++ b/angular/src/app/playground/playground.component.html
@@ -10,7 +10,7 @@
   </p>
 
   <div class="canvas-container">
-    <canvas id="playground_canvas"></canvas>
+    <canvas id="playground-canvas"></canvas>
 
     <!--Popup window with options for the documents-->
     <div class="menu" *ngIf="this.fabric.has_selection()">
@@ -127,6 +127,22 @@
       <div id="playground-help-menu" class="playground-tool-group">
         <button id="playground-help-menu-button" mat-stroked-button class="navbar" [matMenuTriggerFor]="helpmenu">
           <mat-icon fontIcon="question_mark"></mat-icon>
+        </button>
+      </div>
+      <div id="playground-fullscreen-mode-button-container" class="playground-tool-group">
+        <button
+          *ngIf="!this.is_fullscreen"
+          mat-icon-button
+          class="playground-icon playground-fullscreen-mode-button"
+          (click)="this.make_playground_fullscreen()">
+          <mat-icon>fullscreen</mat-icon>
+        </button>
+        <button
+          *ngIf="this.is_fullscreen"
+          mat-icon-button
+          class="playground-icon playground-fullscreen-mode-button"
+          (click)="this.exit_playground_fullscreen()">
+          <mat-icon>fullscreen_exit</mat-icon>
         </button>
       </div>
     </div>

--- a/angular/src/app/playground/playground.component.html
+++ b/angular/src/app/playground/playground.component.html
@@ -6,7 +6,7 @@
   </p>
 
   <div class="canvas-container">
-    <canvas id="playground_canvas"></canvas>
+    <canvas id="playground-canvas"></canvas>
 
     <!--Popup window with options for the documents-->
     <div class="menu" *ngIf="this.fabric.has_selection()">
@@ -123,6 +123,22 @@
       <div id="playground-help-menu" class="playground-tool-group">
         <button id="playground-help-menu-button" mat-stroked-button class="navbar" [matMenuTriggerFor]="helpmenu">
           <mat-icon fontIcon="question_mark"></mat-icon>
+        </button>
+      </div>
+      <div id="playground-fullscreen-mode-button-container" class="playground-tool-group">
+        <button
+          *ngIf="!this.is_fullscreen"
+          mat-icon-button
+          class="playground-icon playground-fullscreen-mode-button"
+          (click)="this.make_playground_fullscreen()">
+          <mat-icon>fullscreen</mat-icon>
+        </button>
+        <button
+          *ngIf="this.is_fullscreen"
+          mat-icon-button
+          class="playground-icon playground-fullscreen-mode-button"
+          (click)="this.exit_playground_fullscreen()">
+          <mat-icon>fullscreen_exit</mat-icon>
         </button>
       </div>
     </div>

--- a/angular/src/app/playground/playground.component.scss
+++ b/angular/src/app/playground/playground.component.scss
@@ -1,5 +1,13 @@
 /* Playground related CSS */
 @use "../_mixins.scss" as *;
+#playground {
+  background-color: white; // This is specifically needed in fullscreen mode.
+}
+
+#playground-canvas {
+  height: 85vh !important; // Sets the height of the canvas in relation to the user's viewport.
+  //TODO make this more elegant for example by having the canvas inherit height from its container.
+}
 
 #playground {
   background-color: white; // This is specifically needed in fullscreen mode.
@@ -254,4 +262,8 @@ hr.playground-divider-top {
 .playground-icon:hover {
   transition: transform 0.2s ease-out;
   transform: scale(1.25);
+}
+
+.playground-fullscreen-mode-button {
+  background-color: transparent;
 }

--- a/angular/src/app/playground/playground.component.scss
+++ b/angular/src/app/playground/playground.component.scss
@@ -267,3 +267,13 @@ hr.playground-divider-top {
 .playground-fullscreen-mode-button {
   background-color: transparent;
 }
+
+.playground-fullscreen-mode-button .mat-icon {
+  font-size: 32px;
+  vertical-align: middle;
+  height: 100%;
+  width: 100%;
+  display: inline-flex;
+  justify-content: center;
+  line-height: 0.95;
+}

--- a/angular/src/app/playground/playground.component.scss
+++ b/angular/src/app/playground/playground.component.scss
@@ -245,3 +245,13 @@ button.button-dashed-background {
 .playground-fullscreen-mode-button {
   background-color: transparent;
 }
+
+.playground-fullscreen-mode-button .mat-icon {
+  font-size: 32px;
+  vertical-align: middle;
+  height: 100%;
+  width: 100%;
+  display: inline-flex;
+  justify-content: center;
+  line-height: 0.95;
+}

--- a/angular/src/app/playground/playground.component.scss
+++ b/angular/src/app/playground/playground.component.scss
@@ -1,5 +1,13 @@
 /* Playground related CSS */
 @use "../_mixins.scss" as *;
+#playground {
+  background-color: white; // This is specifically needed in fullscreen mode.
+}
+
+#playground-canvas {
+  height: 85vh !important; // Sets the height of the canvas in relation to the user's viewport.
+  //TODO make this more elegant for example by having the canvas inherit height from its container.
+}
 
 #playground {
   background-color: white; // This is specifically needed in fullscreen mode.
@@ -232,4 +240,8 @@ button.button-dashed-background {
 .playground-icon:hover {
   transition: transform 0.2s ease-out;
   transform: scale(1.25);
+}
+
+.playground-fullscreen-mode-button {
+  background-color: transparent;
 }

--- a/angular/src/app/playground/playground.component.scss
+++ b/angular/src/app/playground/playground.component.scss
@@ -4,18 +4,8 @@
   background-color: white; // This is specifically needed in fullscreen mode.
 }
 
-#playground-canvas {
-  height: 85vh !important; // Sets the height of the canvas in relation to the user's viewport.
-  //TODO make this more elegant for example by having the canvas inherit height from its container.
-}
-
 #playground {
   background-color: white; // This is specifically needed in fullscreen mode.
-}
-
-#playground-canvas {
-  height: 85vh !important; // Sets the height of the canvas in relation to the user's viewport.
-  //TODO make this more elegant for example by having the canvas inherit height from its container.
 }
 
 #playground-hamburger-menu {
@@ -138,10 +128,6 @@
 
 .zlayer {
   z-index: var(--layer);
-}
-
-.playground-height-padding {
-  min-height: 150ch;
 }
 
 button.button-dashed-background {

--- a/angular/src/app/playground/playground.component.ts
+++ b/angular/src/app/playground/playground.component.ts
@@ -405,7 +405,7 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
    * @author Ycreak
    */
   private init_playground(): void {
-    this.fabric.canvas = new fabric.Canvas('playground_canvas');
+    this.fabric.canvas = new fabric.Canvas('playground-canvas');
     this.fabric.set_event_handlers();
     this.fabric.init();
   }
@@ -415,7 +415,7 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
    * @author sajvanwijk
    */
   protected show_helpmenu(helpmenuoption: string): void {
-    let helptext;
+    let helptext = "";
     if (helpmenuoption == 'a') {
       helptext = `<div><b>This is the playground</b><br><br>
       This is a place to take fragments and move them around in a freeform way, as to gain new insights. 
@@ -441,5 +441,17 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
       </div>`;
     }
     this.dialog.open_custom_dialog(helptext);
+  }
+
+  protected make_playground_fullscreen(): void {
+    document.querySelector('#playground').requestFullscreen();
+  }
+
+  protected exit_playground_fullscreen(): void {
+    if (document) document.exitFullscreen();
+  }
+
+  get is_fullscreen(): boolean {
+    return document.fullscreenElement !== null;
   }
 }

--- a/angular/src/app/playground/playground.component.ts
+++ b/angular/src/app/playground/playground.component.ts
@@ -412,7 +412,6 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
 
   /**
    * Shows the help menu for the playground
-   * @author sajvanwijk
    */
   protected show_helpmenu(helpmenuoption: string): void {
     let helptext = "";

--- a/angular/src/main.ts
+++ b/angular/src/main.ts
@@ -10,6 +10,7 @@ import { provideRouter, Routes } from '@angular/router';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { HttpErrorInterceptor } from './app/api.service';
 import { HTTP_INTERCEPTORS, withInterceptorsFromDi, provideHttpClient } from '@angular/common/http';
+import { FullscreenOverlayContainer, OverlayContainer } from '@angular/cdk/overlay';
 
 const appRoutes: Routes = [
   { path: '', component: OverviewComponent },
@@ -34,5 +35,6 @@ bootstrapApplication(AppComponent, {
     provideHttpClient(withInterceptorsFromDi()),
     provideRouter(appRoutes),
     provideAnimations(),
+    { provide: OverlayContainer, useClass: FullscreenOverlayContainer },
   ],
 }).catch((err) => console.error(err));

--- a/angular/src/styles.scss
+++ b/angular/src/styles.scss
@@ -52,7 +52,7 @@ div.dialog-header {
   color: white;
   /*TODO: duplicate with dialogs.scss */
   /*background-color: mat.m2-get_color_from_palette(mat.$m2-pink-palette, "A200"); */
-  background-color: pink
+  background-color: pink;
 }
 div.dialog-header h2 {
   font-size: 1.5em;
@@ -96,3 +96,11 @@ div.dialog-header button:hover {
   font-size: 18px;
 }
 
+/* Drawer behaviour */
+#playground-drawer {
+  height: 100%;
+}
+
+#playground-drawer div.mat-drawer-inner-container {
+  overflow-y: hidden;
+}


### PR DESCRIPTION
The fullscreen mode button for the playground seems to work as expected again! (At least on my machine; let me know if you still have issues ;) )

I also fixed the scrolling behaviour of the playground a bit and removed the playground's scrollbar. The playground doesn't need it and it was causing the playground buttons to scroll out of view sometimes, with no clear way to get them back. So that should now be fixed.

Shall we merge this?


Closes #393 