### PR TITLE
Add multiple choice questions to the playground

### DIFF
--- a/angular/src/app/components/dialogs/wysiwyg/wysiwyg-dialog.component.spec.ts
+++ b/angular/src/app/components/dialogs/wysiwyg/wysiwyg-dialog.component.spec.ts
@@ -1,17 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { WysiwygComponent } from './wysiwyg.component';
+import { WYSIWYGDialogComponent } from './wysiwyg-dialog.component';
 
-describe('WysiwygComponent', () => {
-  let component: WysiwygComponent;
-  let fixture: ComponentFixture<WysiwygComponent>;
+describe('WYSIWYGDialogComponent', () => {
+  let component: WYSIWYGDialogComponent;
+  let fixture: ComponentFixture<WYSIWYGDialogComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WysiwygComponent],
+      imports: [WYSIWYGDialogComponent],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(WysiwygComponent);
+    fixture = TestBed.createComponent(WYSIWYGDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/angular/src/app/components/quill/quill.component.spec.ts
+++ b/angular/src/app/components/quill/quill.component.spec.ts
@@ -1,17 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { WysiwygComponent } from './wysiwyg.component';
+import { QuillComponent } from './quill.component';
 
-describe('WysiwygComponent', () => {
-  let component: WysiwygComponent;
-  let fixture: ComponentFixture<WysiwygComponent>;
+describe('QuillComponent', () => {
+  let component: QuillComponent;
+  let fixture: ComponentFixture<QuillComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WysiwygComponent],
+      imports: [QuillComponent],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(WysiwygComponent);
+    fixture = TestBed.createComponent(QuillComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/angular/src/app/features/columns/columns.component.spec.ts
+++ b/angular/src/app/features/columns/columns.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { FragmentsComponent } from './fragments.component';
+import { ColumnsComponent } from './columns.component';
 
-describe('FragmentsComponent', () => {
-  let component: FragmentsComponent;
-  let fixture: ComponentFixture<FragmentsComponent>;
+describe('ColumnsComponent', () => {
+  let component: ColumnsComponent;
+  let fixture: ComponentFixture<ColumnsComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FragmentsComponent],
+      imports: [ColumnsComponent],
     }).compileComponents();
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(FragmentsComponent);
+    fixture = TestBed.createComponent(ColumnsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/angular/src/app/features/columns/services/columns.service.spec.ts
+++ b/angular/src/app/features/columns/services/columns.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { ColumnHandlerService } from './column-handler.service';
+import { ColumnsService } from './columns.service';
 
-describe('ColumnHandlerService', () => {
-  let service: ColumnHandlerService;
+describe('ColumnsService', () => {
+  let service: ColumnsService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(ColumnHandlerService);
+    service = TestBed.inject(ColumnsService);
   });
 
   it('should be created', () => {

--- a/angular/src/app/features/commentary/services/commentary.service.spec.ts
+++ b/angular/src/app/features/commentary/services/commentary.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { CommentaryService } from '../commentary.service';
+import { CommentaryService } from './commentary.service';
 
 describe('CommentaryService', () => {
   let service: CommentaryService;

--- a/angular/src/app/features/dashboard/components/introductions-dashboard/introductions-dashboard.component.spec.ts
+++ b/angular/src/app/features/dashboard/components/introductions-dashboard/introductions-dashboard.component.spec.ts
@@ -1,17 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { TestimoniaDashboardComponent } from './testimonia-dashboard.component';
+import { IntroductionsDashboardComponent } from './introductions-dashboard.component';
 
-describe('TestimoniaDashboardComponent', () => {
-  let component: TestimoniaDashboardComponent;
-  let fixture: ComponentFixture<TestimoniaDashboardComponent>;
+describe('IntroductionsDashboardComponent', () => {
+  let component: IntroductionsDashboardComponent;
+  let fixture: ComponentFixture<IntroductionsDashboardComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TestimoniaDashboardComponent],
+      imports: [IntroductionsDashboardComponent],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(TestimoniaDashboardComponent);
+    fixture = TestBed.createComponent(IntroductionsDashboardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/angular/src/app/features/dashboard/dashboard.component.scss
+++ b/angular/src/app/features/dashboard/dashboard.component.scss
@@ -1,4 +1,4 @@
-@import url("@oscc/app.component.scss");
+@import "../../app.component.scss";
 /* Dashboard component specific CSS. For more generic CSS, see ../app.component.scss. */
 
 /* Input form CSS */

--- a/angular/src/app/features/dashboard/services/helper.service.spec.ts
+++ b/angular/src/app/features/dashboard/services/helper.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { HelperService } from '../helper.service';
+import { HelperService } from './helper.service';
 
 describe('HelperService', () => {
   let service: HelperService;

--- a/angular/src/app/features/filters/components/introductions-filter/introductions-filter.component.spec.ts
+++ b/angular/src/app/features/filters/components/introductions-filter/introductions-filter.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { LatinTragicFragmentFilterComponent } from './latin-tragic-fragment-filter.component';
+import { LatinTragicFragmentFilterComponent } from '../latin-tragic-fragment-filter/latin-tragic-fragment-filter.component';
 
 describe('LatinTragicFragmentFilterComponent', () => {
   let component: LatinTragicFragmentFilterComponent;

--- a/angular/src/app/features/filters/components/testimonium-filter/testimonium-filter.component.spec.ts
+++ b/angular/src/app/features/filters/components/testimonium-filter/testimonium-filter.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { LatinTragicFragmentFilterComponent } from './latin-tragic-fragment-filter.component';
+import { LatinTragicFragmentFilterComponent } from '../latin-tragic-fragment-filter/latin-tragic-fragment-filter.component';
 
 describe('LatinTragicFragmentFilterComponent', () => {
   let component: LatinTragicFragmentFilterComponent;

--- a/angular/src/app/features/filters/services/filter.service.spec.ts
+++ b/angular/src/app/features/filters/services/filter.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { FilterService } from '../components/document-filter/filter.service';
+import { FilterService } from './filter.service';
 
 describe('FilterService', () => {
   let service: FilterService;

--- a/angular/src/app/features/playground/components/add-question/add-question.component.html
+++ b/angular/src/app/features/playground/components/add-question/add-question.component.html
@@ -1,0 +1,54 @@
+<div class="dialog-header">
+  <h2>Add multiple choice question</h2>
+  <button mat-icon-button [mat-dialog-close]="null" [disableRipple]="true">
+    <mat-icon>clear</mat-icon>
+  </button>
+</div>
+<form [formGroup]="form" (ngSubmit)="submit()">
+  <div mat-dialog-content>
+    <mat-form-field class="question-field">
+      <mat-label>Question</mat-label>
+      <textarea matInput formControlName="question" rows="3"></textarea>
+      @if (form.get('question').hasError('required') || form.get('question').hasError('whitespace')) {
+        <mat-error>A question is required</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-radio-group formControlName="correct_index" class="choices-list">
+      <div formArrayName="choices">
+        @for (choice of choices.controls; track choice; let i = $index) {
+          <div class="choice-row">
+            <mat-radio-button [value]="i" title="Mark as correct answer"></mat-radio-button>
+            <mat-form-field class="choice-field">
+              <mat-label>Choice {{ choice_label(i) }}</mat-label>
+              <input matInput [formControlName]="i" />
+              @if (choice.hasError('required') || choice.hasError('whitespace')) {
+                <mat-error>Choice may not be empty</mat-error>
+              }
+            </mat-form-field>
+            @if (choices.length > min_choices) {
+              <button mat-icon-button type="button" title="Remove choice" (click)="remove_choice(i)">
+                <mat-icon>delete</mat-icon>
+              </button>
+            }
+          </div>
+        }
+      </div>
+    </mat-radio-group>
+    @if (form.get('correct_index').touched && form.get('correct_index').hasError('required')) {
+      <p class="correct-answer-error">Select the correct answer with the radio buttons</p>
+    }
+    @if (choices.length < max_choices) {
+      <button mat-button type="button" (click)="add_choice()"><mat-icon>add</mat-icon> Add choice</button>
+    }
+
+    <mat-form-field class="question-field">
+      <mat-label>Explanation (optional, shown after answering)</mat-label>
+      <textarea matInput formControlName="explanation" rows="2"></textarea>
+    </mat-form-field>
+  </div>
+  <div mat-dialog-actions>
+    <button mat-button type="button" (click)="onNoClick()">Cancel</button>
+    <button mat-button type="submit" cdkFocusInitial>Add question</button>
+  </div>
+</form>

--- a/angular/src/app/features/playground/components/add-question/add-question.component.scss
+++ b/angular/src/app/features/playground/components/add-question/add-question.component.scss
@@ -1,0 +1,30 @@
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0.5em 0 1.5em;
+}
+
+.question-field {
+  width: 100%;
+}
+
+.choices-list {
+  display: block;
+}
+
+.choice-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5em;
+}
+
+.choice-field {
+  flex: 1;
+}
+
+.correct-answer-error {
+  color: var(--mat-form-field-error-text-color, #f44336);
+  font-size: 0.75em;
+  margin: 0 0 0.5em;
+}

--- a/angular/src/app/features/playground/components/add-question/add-question.component.spec.ts
+++ b/angular/src/app/features/playground/components/add-question/add-question.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { AddQuestionComponent } from './add-question.component';
+import { Playground_question } from '@oscc/features/playground/types/Playground_question';
+
+describe('AddQuestionComponent', () => {
+  let component: AddQuestionComponent;
+  let fixture: ComponentFixture<AddQuestionComponent>;
+  let dialog_ref: jasmine.SpyObj<MatDialogRef<AddQuestionComponent>>;
+
+  beforeEach(async () => {
+    dialog_ref = jasmine.createSpyObj('MatDialogRef', ['close']);
+    await TestBed.configureTestingModule({
+      imports: [AddQuestionComponent],
+      providers: [provideNoopAnimations(), { provide: MatDialogRef, useValue: dialog_ref }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddQuestionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should not close the dialog when the form is invalid', () => {
+    (component as any).submit();
+    expect(dialog_ref.close).not.toHaveBeenCalled();
+  });
+
+  it('should close with a valid question when the form is filled in', () => {
+    const form = (component as any).form;
+    form.get('question').setValue('What form would we expect in Classical Latin?');
+    form.get('choices').setValue(['ipsi', 'ipso', 'ipsa', 'ipse']);
+    form.get('correct_index').setValue(3);
+    (component as any).submit();
+
+    expect(dialog_ref.close).toHaveBeenCalled();
+    const question = dialog_ref.close.calls.mostRecent().args[0];
+    expect(Playground_question.is_valid(question)).toBeTrue();
+    expect(question.correct_index).toBe(3);
+  });
+
+  it('should keep the correct answer pointing at the same choice when removing one above it', () => {
+    const form = (component as any).form;
+    form.get('correct_index').setValue(3);
+    (component as any).remove_choice(0);
+    expect(form.get('correct_index').value).toBe(2);
+  });
+
+  it('should reset the correct answer when the chosen choice is removed', () => {
+    const form = (component as any).form;
+    form.get('correct_index').setValue(1);
+    (component as any).remove_choice(1);
+    expect(form.get('correct_index').value).toBeNull();
+  });
+});

--- a/angular/src/app/features/playground/components/add-question/add-question.component.ts
+++ b/angular/src/app/features/playground/components/add-question/add-question.component.ts
@@ -1,0 +1,122 @@
+// Library imports
+import { Component } from '@angular/core';
+import { MatDialogRef, MatDialogClose, MatDialogContent, MatDialogActions } from '@angular/material/dialog';
+
+import { FormArray, FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatRadioModule } from '@angular/material/radio';
+
+// Model imports
+import { Playground_question } from '@oscc/features/playground/types/Playground_question';
+
+/**
+ * Dialog to compose a multiple choice question. Returns a valid Playground_question
+ * on close, or nothing when cancelled.
+ */
+@Component({
+  selector: 'app-add-question',
+  templateUrl: './add-question.component.html',
+  styleUrls: ['./add-question.component.scss'],
+  standalone: true,
+  imports: [
+    MatButtonModule,
+    MatDialogClose,
+    MatIconModule,
+    MatDialogContent,
+    MatFormFieldModule,
+    MatInputModule,
+    MatRadioModule,
+    ReactiveFormsModule,
+    MatDialogActions,
+  ],
+})
+export class AddQuestionComponent {
+  protected readonly min_choices = 2;
+  protected readonly max_choices = 6;
+
+  protected form: FormGroup;
+
+  constructor(
+    private form_builder: FormBuilder,
+    public dialogRef: MatDialogRef<AddQuestionComponent>
+  ) {
+    this.form = this.form_builder.group({
+      question: new FormControl('', [Validators.required, this.no_whitespace_validator]),
+      choices: this.form_builder.array([this.build_choice(), this.build_choice(), this.build_choice(), this.build_choice()]),
+      correct_index: new FormControl<number | null>(null, Validators.required),
+      explanation: new FormControl(''),
+    });
+  }
+
+  protected get choices(): FormArray {
+    return this.form.get('choices') as FormArray;
+  }
+
+  /**
+   * Returns the label for the choice at the given index, e.g. 'a)'
+   * @param index (number) of the choice
+   * @return string
+   */
+  protected choice_label(index: number): string {
+    return `${String.fromCharCode(97 + index)})`;
+  }
+
+  protected add_choice(): void {
+    if (this.choices.length < this.max_choices) {
+      this.choices.push(this.build_choice());
+    }
+  }
+
+  /**
+   * Removes the choice at the given index and keeps the selected correct answer
+   * pointing at the same choice.
+   * @param index (number) of the choice to remove
+   */
+  protected remove_choice(index: number): void {
+    if (this.choices.length <= this.min_choices) {
+      return;
+    }
+    this.choices.removeAt(index);
+    const correct_control = this.form.get('correct_index');
+    const correct_index = correct_control.value;
+    if (correct_index === index) {
+      correct_control.setValue(null);
+    } else if (correct_index !== null && correct_index > index) {
+      correct_control.setValue(correct_index - 1);
+    }
+  }
+
+  /**
+   * Validates the form and closes the dialog with the composed question
+   */
+  protected submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    const question = new Playground_question({
+      question: this.form.value.question.trim(),
+      choices: this.form.value.choices.map((choice: string) => choice.trim()),
+      correct_index: this.form.value.correct_index,
+      explanation: this.form.value.explanation ? this.form.value.explanation.trim() : '',
+    });
+    this.dialogRef.close(question);
+  }
+
+  protected onNoClick(): void {
+    this.dialogRef.close();
+  }
+
+  private build_choice(): FormControl {
+    return new FormControl('', [Validators.required, this.no_whitespace_validator]);
+  }
+
+  private no_whitespace_validator(control: FormControl): { [key: string]: boolean } | null {
+    return typeof control.value === 'string' && control.value.trim().length === 0 && control.value.length > 0
+      ? { whitespace: true }
+      : null;
+  }
+}

--- a/angular/src/app/features/playground/playground.component.html
+++ b/angular/src/app/features/playground/playground.component.html
@@ -196,6 +196,10 @@ Join Shared Session
   <div class="menu-item-icon-wrapper"></div>
   Add Question
 </button>
+<button mat-menu-item (click)="this.load_basil_quiz()">
+  <div class="menu-item-icon-wrapper"></div>
+  Load Basil Quiz
+</button>
 <button mat-menu-item (click)="fabric.randomize_positions()">
   <div class="menu-item-icon-wrapper"></div>
   Scatter documents

--- a/angular/src/app/features/playground/playground.component.html
+++ b/angular/src/app/features/playground/playground.component.html
@@ -54,6 +54,13 @@
           [src]="playgroundAddNoteButton"
           (click)="this.fabric.add_note('edit me')" />
       </span>
+      <span id="playground_addquestion_btn_tooltip" class="playground_btn_tooltip">
+        <mat-icon
+          id="playground_question_btn"
+          class="playground-icon playground-question-icon"
+          fontIcon="quiz"
+          (click)="this.open_add_question()"></mat-icon>
+      </span>
       <span id="playground_clear_btn_tooltip" class="playground_btn_tooltip">
         <img
           id="playground_clear_btn"
@@ -185,6 +192,10 @@
 </div>
 Join Shared Session
 </button> -->
+<button mat-menu-item (click)="this.open_add_question()">
+  <div class="menu-item-icon-wrapper"></div>
+  Add Question
+</button>
 <button mat-menu-item (click)="fabric.randomize_positions()">
   <div class="menu-item-icon-wrapper"></div>
   Scatter documents

--- a/angular/src/app/features/playground/playground.component.html
+++ b/angular/src/app/features/playground/playground.component.html
@@ -54,13 +54,15 @@
           [src]="playgroundAddNoteButton"
           (click)="this.fabric.add_note('edit me')" />
       </span>
-      <span id="playground_addquestion_btn_tooltip" class="playground_btn_tooltip">
-        <mat-icon
-          id="playground_question_btn"
-          class="playground-icon playground-question-icon"
-          fontIcon="quiz"
-          (click)="this.open_add_question()"></mat-icon>
-      </span>
+      @if (questions_enabled) {
+        <span id="playground_addquestion_btn_tooltip" class="playground_btn_tooltip">
+          <mat-icon
+            id="playground_question_btn"
+            class="playground-icon playground-question-icon"
+            fontIcon="quiz"
+            (click)="this.open_add_question()"></mat-icon>
+        </span>
+      }
       <span id="playground_clear_btn_tooltip" class="playground_btn_tooltip">
         <img
           id="playground_clear_btn"
@@ -192,14 +194,16 @@
 </div>
 Join Shared Session
 </button> -->
-<button mat-menu-item (click)="this.open_add_question()">
-  <div class="menu-item-icon-wrapper"></div>
-  Add Question
-</button>
-<button mat-menu-item (click)="this.load_basil_quiz()">
-  <div class="menu-item-icon-wrapper"></div>
-  Load Basil Quiz
-</button>
+@if (questions_enabled) {
+  <button mat-menu-item (click)="this.open_add_question()">
+    <div class="menu-item-icon-wrapper"></div>
+    Add Question
+  </button>
+  <button mat-menu-item (click)="this.load_basil_quiz()">
+    <div class="menu-item-icon-wrapper"></div>
+    Load Basil Quiz
+  </button>
+}
 <button mat-menu-item (click)="fabric.randomize_positions()">
   <div class="menu-item-icon-wrapper"></div>
   Scatter documents

--- a/angular/src/app/features/playground/playground.component.scss
+++ b/angular/src/app/features/playground/playground.component.scss
@@ -216,6 +216,10 @@ button.button-dashed-background {
   box-sizing: content-box;
 }
 
+.playground-question-icon {
+  font-size: 32px;
+}
+
 .playground-icon:first-child {
   border-left-width: 10px;
 }
@@ -256,6 +260,10 @@ button.button-dashed-background {
 #playground_addnote_btn_tooltip::after {
   content: "Add note";
   left: 14px;
+}
+#playground_addquestion_btn_tooltip::after {
+  content: "Add question";
+  left: 8px;
 }
 #playground_clear_btn_tooltip::after {
   content: "Clear playground";

--- a/angular/src/app/features/playground/playground.component.ts
+++ b/angular/src/app/features/playground/playground.component.ts
@@ -40,6 +40,7 @@ import { Playground_communicator } from '@oscc/features/playground/types/Playgro
 
 import { Playground_question } from '@oscc/features/playground/types/Playground_question';
 import { BASIL_QUIZ } from '@oscc/features/playground/types/basil_quiz';
+import { environment } from '@src/environments/environment';
 
 // Component imports
 import { AddQuestionComponent } from './components/add-question/add-question.component';
@@ -95,6 +96,9 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
 
   private canvas_change_subscription: Subscription;
   private websockets_subscription: Subscription;
+
+  // Feature flag for the teaching-package question UI (issue #436)
+  protected questions_enabled = environment.questions_enabled;
 
   protected playgroundSearchFragmentButton = PLAYGROUND_SEARCH_FRAGMENT;
   protected playgroundAddNoteButton = PLAYGROUND_ADD_NOTE;

--- a/angular/src/app/features/playground/playground.component.ts
+++ b/angular/src/app/features/playground/playground.component.ts
@@ -39,6 +39,7 @@ import { DialogService } from '@oscc/services/dialog.service';
 import { Playground_communicator } from '@oscc/features/playground/types/Playground_communicator';
 
 import { Playground_question } from '@oscc/features/playground/types/Playground_question';
+import { BASIL_QUIZ } from '@oscc/features/playground/types/basil_quiz';
 
 // Component imports
 import { AddQuestionComponent } from './components/add-question/add-question.component';
@@ -185,6 +186,16 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
           this.fabric.add_question(question);
         }
       },
+    });
+  }
+
+  /**
+   * Places the predefined Basil quiz questions on the canvas, diagonally offset
+   * so every card stays visible.
+   */
+  protected load_basil_quiz(): void {
+    BASIL_QUIZ.forEach((question, index) => {
+      this.fabric.add_question(new Playground_question(question), index * 40);
     });
   }
 

--- a/angular/src/app/features/playground/playground.component.ts
+++ b/angular/src/app/features/playground/playground.component.ts
@@ -38,7 +38,10 @@ import { Fragment } from '@oscc/types/Fragment';
 import { DialogService } from '@oscc/services/dialog.service';
 import { Playground_communicator } from '@oscc/features/playground/types/Playground_communicator';
 
+import { Playground_question } from '@oscc/features/playground/types/Playground_question';
+
 // Component imports
+import { AddQuestionComponent } from './components/add-question/add-question.component';
 import { LoadPlaygroundComponent } from './components/load-playground/load-playground.component';
 import { SavePlaygroundComponent } from './components/save-playground/save-playground.component';
 import { DeletePlaygroundComponent } from './components/delete-playground/delete-playground.component';
@@ -172,6 +175,20 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Opens the add question dialog. If it returns with a question, we place it on the canvas.
+   */
+  protected open_add_question(): void {
+    const dialogRef = this.mat_dialog.open(AddQuestionComponent, {});
+    dialogRef.afterClosed().subscribe({
+      next: (question: Playground_question) => {
+        if (question) {
+          this.fabric.add_question(question);
+        }
+      },
+    });
+  }
+
+  /**
    */
   protected open_clear_playground(): void {
     this.dialog.open_confirmation_dialog('Are you sure you want to clear the playground?', '').subscribe({
@@ -224,7 +241,7 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
             this.api.post_document(
               new Playground_communicator({
                 name: data.name,
-                canvas: this.fabric.canvas.toJSON(),
+                canvas: this.fabric.export_canvas(),
                 _id: this._id,
               }),
               'update'
@@ -237,7 +254,7 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
             .post_document(
               new Playground_communicator({
                 name: data.name,
-                canvas: this.fabric.canvas.toJSON(),
+                canvas: this.fabric.export_canvas(),
                 created_by: this.auth_service.current_user_name,
                 users: [
                   new Playground_user({
@@ -291,7 +308,7 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
     //});
     // Take a subscription to canvas changes. These we will send to the websocket
     this.canvas_change_subscription = this.fabric.canvas_changed_subject.subscribe(() => {
-      this.websockets.send_json(this.fabric.canvas.toJSON());
+      this.websockets.send_json(this.fabric.export_canvas());
     });
   }
 

--- a/angular/src/app/features/playground/services/fabric.service.spec.ts
+++ b/angular/src/app/features/playground/services/fabric.service.spec.ts
@@ -1,9 +1,19 @@
 import { TestBed } from '@angular/core/testing';
+import { Canvas } from 'fabric';
 
 import { FabricService } from './fabric.service';
+import { Playground_question } from '@oscc/features/playground/types/Playground_question';
 
 describe('FabricService', () => {
   let service: FabricService;
+
+  const valid_question = () =>
+    new Playground_question({
+      question: 'What form of ipsus would we expect in Classical Latin?',
+      choices: ['ipsi', 'ipso', 'ipsa', 'ipse'],
+      correct_index: 3,
+      explanation: 'ipsus is an Early Latin variant of ipse.',
+    });
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
@@ -12,5 +22,87 @@ describe('FabricService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('with a canvas', () => {
+    beforeEach(() => {
+      const element = document.createElement('canvas');
+      element.width = 800;
+      element.height = 600;
+      service.canvas = new Canvas(element);
+    });
+
+    afterEach(async () => {
+      await service.canvas.dispose();
+    });
+
+    const find_question_group = (): any =>
+      service.canvas.getObjects().find((obj: any) => service.is_question(obj));
+
+    it('should add a question card to the canvas', () => {
+      service.add_question(valid_question());
+      const group = find_question_group();
+      expect(group).toBeTruthy();
+      expect(group.quiz.correct_index).toBe(3);
+      expect(group.subTargetCheck).toBeTrue();
+      // One child per choice, plus a hidden feedback textbox
+      const choices = group.getObjects().filter((child: any) => child.quiz_choice !== undefined);
+      const feedback = group.getObjects().find((child: any) => child.quiz_feedback);
+      expect(choices.length).toBe(4);
+      expect(feedback.visible).toBeFalse();
+    });
+
+    it('should not add an invalid question', () => {
+      service.add_question(new Playground_question({ question: '', choices: ['a'], correct_index: 5 }));
+      expect(find_question_group()).toBeUndefined();
+    });
+
+    it('should reveal the answer when a choice is answered', () => {
+      service.add_question(valid_question());
+      const group = find_question_group();
+      service.answer_question(group, 1);
+
+      expect(group.quiz.answered).toBeTrue();
+      expect(group.quiz.chosen_index).toBe(1);
+      const feedback = group.getObjects().find((child: any) => child.quiz_feedback);
+      expect(feedback.visible).toBeTrue();
+      const correct = group.getObjects().find((child: any) => child.quiz_choice === 3);
+      const chosen = group.getObjects().find((child: any) => child.quiz_choice === 1);
+      expect(correct.fill).toBe('#1B5E20');
+      expect(chosen.fill).toBe('#B71C1C');
+    });
+
+    it('should only allow answering a question once', () => {
+      service.add_question(valid_question());
+      const group = find_question_group();
+      service.answer_question(group, 3);
+      service.answer_question(group, 1);
+      expect(group.quiz.chosen_index).toBe(3);
+    });
+
+    it('should include quiz metadata when exporting the canvas', () => {
+      service.add_question(valid_question());
+      const exported: any = service.export_canvas();
+      const group = exported.objects.find((obj: any) => obj.quiz);
+      expect(group).toBeTruthy();
+      expect(group.quiz.choices.length).toBe(4);
+      expect(group.subTargetCheck).toBeTrue();
+      expect(group.objects.some((child: any) => child.quiz_feedback)).toBeTrue();
+    });
+  });
+
+  describe('Playground_question.is_valid', () => {
+    it('accepts a well-formed question', () => {
+      expect(Playground_question.is_valid(valid_question())).toBeTrue();
+    });
+
+    it('rejects malformed questions', () => {
+      expect(Playground_question.is_valid(null)).toBeFalse();
+      expect(Playground_question.is_valid({ question: ' ', choices: ['a', 'b'], correct_index: 0 })).toBeFalse();
+      expect(Playground_question.is_valid({ question: 'q', choices: ['a'], correct_index: 0 })).toBeFalse();
+      expect(Playground_question.is_valid({ question: 'q', choices: ['a', ''], correct_index: 0 })).toBeFalse();
+      expect(Playground_question.is_valid({ question: 'q', choices: ['a', 'b'], correct_index: 2 })).toBeFalse();
+      expect(Playground_question.is_valid({ question: 'q', choices: ['a', 'b'], correct_index: -1 })).toBeFalse();
+    });
   });
 });

--- a/angular/src/app/features/playground/services/fabric.service.ts
+++ b/angular/src/app/features/playground/services/fabric.service.ts
@@ -466,9 +466,10 @@ export class FabricService {
    * Adds a multiple choice question card to the center of the current view.
    * The choices are clickable: clicking one reveals the correct answer.
    * @param question The question data.
+   * @param offset Optional diagonal offset in pixels, to keep multiple cards visible.
    * @returns void
    */
-  public add_question(question: Playground_question): void {
+  public add_question(question: Playground_question, offset = 0): void {
     if (!Playground_question.is_valid(question)) {
       this.utility.open_snackbar('Invalid question');
       return;
@@ -530,8 +531,8 @@ export class FabricService {
 
     const center = this.get_center();
     const group = new Group([box, ...children], {
-      top: center.y,
-      left: center.x,
+      top: center.y + offset,
+      left: center.x + offset,
       subTargetCheck: true,
       quiz: { ...question },
     } as any);

--- a/angular/src/app/features/playground/services/fabric.service.ts
+++ b/angular/src/app/features/playground/services/fabric.service.ts
@@ -12,6 +12,11 @@ import { Observable, Subject } from 'rxjs';
 import { UtilityService } from '@oscc/services/utility.service';
 import { environment } from '@src/environments/environment';
 
+import { Playground_question } from '@oscc/features/playground/types/Playground_question';
+
+// Custom properties that must survive canvas (de)serialization for save/load and websockets
+const CUSTOM_CANVAS_PROPERTIES = ['identifier', 'quiz', 'quiz_choice', 'quiz_feedback', 'subTargetCheck'];
+
 /**
  * This service handles everything related to fabric and its canvas.
  * The playground component uses this service to visualize and manipulate documents on a fabricjs canvas.
@@ -103,6 +108,17 @@ export class FabricService {
 
       this.canvas.selection = true;
       this.canvas_changed_subject.next({});
+    });
+
+    // Answer a multiple choice question when one of its choices is clicked
+    this.canvas.on('mouse:down', (opt: any) => {
+      const target: any = opt.target;
+      if (target && target.quiz && !target.quiz.answered && opt.subTargets?.length) {
+        const choice = opt.subTargets.find((sub: any) => sub.quiz_choice !== undefined);
+        if (choice) {
+          this.answer_question(target, choice.quiz_choice);
+        }
+      }
     });
 
     // Save state for undo/redo on major changes
@@ -345,7 +361,7 @@ export class FabricService {
     if (this.current_state_index < this.canvas_states.length - 1) {
       this.canvas_states.splice(this.current_state_index + 1);
     }
-    this.canvas_states.push(JSON.stringify(this.canvas));
+    this.canvas_states.push(JSON.stringify(this.export_canvas()));
     this.current_state_index = this.canvas_states.length - 1;
   }
 
@@ -444,6 +460,142 @@ export class FabricService {
       editable: true,
     });
     this.canvas.add(text);
+  }
+
+  /**
+   * Adds a multiple choice question card to the center of the current view.
+   * The choices are clickable: clicking one reveals the correct answer.
+   * @param question The question data.
+   * @returns void
+   */
+  public add_question(question: Playground_question): void {
+    if (!Playground_question.is_valid(question)) {
+      this.utility.open_snackbar('Invalid question');
+      return;
+    }
+    const width = 360;
+    const padding = 15;
+    const spacing = 8;
+
+    const children: any[] = [];
+    const header = new Textbox(question.question, {
+      fontSize: this.font_size,
+      fontWeight: 'bold',
+      width,
+      top: 0,
+      left: 0,
+    });
+    children.push(header);
+    let top = (header.height || 0) + spacing * 2;
+
+    question.choices.forEach((choice, index) => {
+      const choice_text = new Textbox(`${this.choice_label(index)} ${choice}`, {
+        fontSize: this.font_size,
+        width,
+        top,
+        left: 0,
+        quiz_choice: index,
+      } as any);
+      children.push(choice_text);
+      top += (choice_text.height || 0) + spacing;
+    });
+
+    top += spacing;
+    const feedback_lines = [`Answer: ${this.choice_label(question.correct_index)}`];
+    if (question.explanation) {
+      feedback_lines.push(question.explanation);
+    }
+    const feedback = new Textbox(feedback_lines.join('\n'), {
+      fontSize: this.font_size,
+      fontStyle: 'italic',
+      width,
+      top,
+      left: 0,
+      visible: false,
+      quiz_feedback: true,
+    } as any);
+    children.push(feedback);
+
+    const box = new Rect({
+      top: -padding,
+      left: -padding,
+      width: width + padding * 2,
+      height: top + (feedback.height || 0) + padding * 2,
+      fill: '#A8D5BA',
+      rx: 10,
+      ry: 10,
+      stroke: 'black',
+      strokeWidth: 1,
+    });
+
+    const center = this.get_center();
+    const group = new Group([box, ...children], {
+      top: center.y,
+      left: center.x,
+      subTargetCheck: true,
+      quiz: { ...question },
+    } as any);
+    this.canvas.add(group);
+    this.canvas.requestRenderAll();
+  }
+
+  /**
+   * Marks the given question group as answered: colors the chosen and correct
+   * choices and reveals the answer text. A question can only be answered once.
+   * @param group The fabric group carrying the quiz metadata.
+   * @param choice_index The index of the clicked choice.
+   * @returns void
+   */
+  public answer_question(group: any, choice_index: number): void {
+    const quiz = group.quiz;
+    if (!quiz || quiz.answered || !Number.isInteger(choice_index)) {
+      return;
+    }
+    quiz.answered = true;
+    quiz.chosen_index = choice_index;
+
+    group.getObjects().forEach((child: any) => {
+      if (child.quiz_choice === quiz.correct_index) {
+        child.set({ fill: '#1B5E20', fontWeight: 'bold' });
+      } else if (child.quiz_choice === choice_index) {
+        child.set({ fill: '#B71C1C' });
+      }
+      if (child.quiz_feedback) {
+        child.set({ visible: true });
+      }
+    });
+    group.dirty = true;
+    this.canvas.requestRenderAll();
+    // Register the answer in the undo/redo history and notify listeners
+    this.canvas.fire('object:modified', { target: group });
+  }
+
+  /**
+   * Checks if the given object is a multiple choice question
+   * @param thing (object)
+   * @return boolean
+   */
+  public is_question(thing: any): boolean {
+    return !!thing.quiz;
+  }
+
+  /**
+   * Returns the label for the choice at the given index, e.g. 'a)'
+   * @param index (number) of the choice
+   * @return string
+   */
+  private choice_label(index: number): string {
+    return `${String.fromCharCode(97 + index)})`;
+  }
+
+  /**
+   * Serializes the canvas including the custom properties (document identifiers and
+   * quiz metadata) that fabric does not export by default. Use this instead of
+   * canvas.toJSON() whenever the canvas is persisted or sent over the wire.
+   * @returns A plain object representation of the canvas.
+   */
+  public export_canvas(): object {
+    return this.canvas.toObject(CUSTOM_CANVAS_PROPERTIES);
   }
 
   /**

--- a/angular/src/app/features/playground/services/websockets.service.spec.ts
+++ b/angular/src/app/features/playground/services/websockets.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { WebsocketsService } from '../websockets.service';
+import { WebsocketsService } from './websockets.service';
 
 describe('WebsocketsService', () => {
   let service: WebsocketsService;

--- a/angular/src/app/features/playground/types/Playground_question.ts
+++ b/angular/src/app/features/playground/types/Playground_question.ts
@@ -1,0 +1,34 @@
+/** This class represents a multiple choice question placed on the playground canvas */
+export class Playground_question {
+  question: string;
+  choices: string[];
+  correct_index: number;
+  explanation?: string;
+  answered = false;
+  chosen_index?: number;
+
+  constructor(playground_question?: Partial<Playground_question>) {
+    // Allow the partial initialisation of a question object
+    Object.assign(this, playground_question);
+  }
+
+  /**
+   * Checks whether the question is well-formed: a non-empty question, at least two
+   * non-empty choices and a correct_index that points to an existing choice.
+   * @param question (object) candidate question data
+   * @return boolean
+   */
+  public static is_valid(question: any): boolean {
+    return (
+      !!question &&
+      typeof question.question === 'string' &&
+      question.question.trim().length > 0 &&
+      Array.isArray(question.choices) &&
+      question.choices.length >= 2 &&
+      question.choices.every((choice: any) => typeof choice === 'string' && choice.trim().length > 0) &&
+      Number.isInteger(question.correct_index) &&
+      question.correct_index >= 0 &&
+      question.correct_index < question.choices.length
+    );
+  }
+}

--- a/angular/src/app/features/playground/types/basil_quiz.ts
+++ b/angular/src/app/features/playground/types/basil_quiz.ts
@@ -1,0 +1,50 @@
+import { Playground_question } from '@oscc/features/playground/types/Playground_question';
+
+/** Multiple choice questions from the Basil exercise sheet on Roman Republican tragedy.
+ * Open questions from the sheet (2, 6, 9, 10) are omitted: they have no multiple choice format. */
+export const BASIL_QUIZ: Playground_question[] = [
+  new Playground_question({
+    question:
+      'Consider fr. adesp. 96 TRF Adespoton (cur fugit fratrem? scit ipse). What information can we deduce on the basis of this fragment?',
+    choices: [
+      'That the speaker is a messenger.',
+      'That the play involved two brothers.',
+      'That the speaker is one of the two brothers.',
+      'That there was a decades-long feud between two brothers.',
+    ],
+    correct_index: 1,
+  }),
+  new Playground_question({
+    question:
+      'Consider the following fragment: video sepulcra dua duorum corpurum, "I see two tombs of (or for?) two corpses" (Accius, incertum, F 406 TRF). Read the fragment reconstruction section. To which play has this fragment NOT been attributed?',
+    choices: ['Atreus', 'Aegisthus', 'Stasiastae', 'Clytemnestra'],
+    correct_index: 2,
+  }),
+  new Playground_question({
+    question:
+      'Consider Accius Atreus F 104.1 TRF (ipsus hortatur me frater, ut meos malis miser | manderem natos). Look at the form ipsus, which is sometimes found in Early Latin. What form of this word would we expect to find in Classical Latin (e.g. the Latin of Cicero)?',
+    choices: ['ipsi', 'ipso', 'ipsa', 'ipse'],
+    correct_index: 3,
+  }),
+  new Playground_question({
+    question:
+      'Consider Accius Atreus F 108 TRF (concoquit | partem uapore flammae; tribuit in focos | ueribus lacerta). What word makes it clear that human body parts are being cooked and not animal ones?',
+    choices: ['veribus', 'lacerta', 'partem', 'concoquit'],
+    correct_index: 1,
+    explanation:
+      'lacertus, -i, m. (here in the neuter form, lacertum, -i, n.), which is only ever used to denote a human arm.',
+  }),
+  new Playground_question({
+    question:
+      'Consider Accius Aegisthus F 7 TRF (cui manus materno sordet sparso sanguine, "whose hand is soiled by his/her mother\'s spattered blood"). Based on your knowledge of Greek mythology, which character could this fragment not describe?',
+    choices: ['Orestes', 'Electra', 'Pentheus', 'Alcmaeon'],
+    correct_index: 2,
+    explanation: 'Pentheus does not kill his mother Agave but is killed by her.',
+  }),
+  new Playground_question({
+    question:
+      'In Accius Atreus 103.4, a character says oderint, dum metuant ("let them hate me, so long as they fear me"). With which type of character would you most readily associate this statement?',
+    choices: ['A king.', 'An actor.', 'A soldier.', 'A slave.'],
+    correct_index: 0,
+  }),
+];

--- a/angular/src/app/services/local-storage.service.spec.ts
+++ b/angular/src/app/services/local-storage.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { LocalStorageService } from '../utils/local-storage.service';
+import { LocalStorageService } from './local-storage.service';
 
 describe('LocalStorageService', () => {
   let service: LocalStorageService;

--- a/angular/src/environments/environment.prod.ts
+++ b/angular/src/environments/environment.prod.ts
@@ -7,7 +7,9 @@ export const environment = {
   current_user_role: 'guest',
   production: true,
   debug: false,
-  
+  // Toggle off to remove the playground "add questions" teaching feature (issue #436)
+  questions_enabled: true,
+
   fragments: 'fragments',
   fragment: 'fragment',
   testimonia: 'testimonia',

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -12,6 +12,8 @@ export const environment = {
   current_user_role: 'admin',
   production: false,
   debug: true,
+  // Toggle off to remove the playground "add questions" teaching feature (issue #436)
+  questions_enabled: true,
 
   fragments: 'fragments',
   fragment: 'fragment',


### PR DESCRIPTION
## What

Adds multiple choice quiz questions to the playground, for exercises like the Basil sheet on Roman Republican tragedy.

- **Add question dialog** (toolbar quiz icon or hamburger menu > Add Question): question text, 2-6 choices, mark the correct answer, optional explanation. Validated with reactive forms.
- **Interactive question cards on the canvas**: clicking a choice reveals the answer - wrong choice turns red, correct one green, and the answer line plus explanation appear. Each question can only be answered once.
- **Preset**: hamburger menu > Load Basil Quiz places the six multiple choice questions from the Basil exercise sheet on the canvas.

## Persistence fix

Fabric does not serialize custom properties by default, so quiz metadata (and the existing document `identifier` property) was lost on save/load, undo/redo and websocket sync. Canvas serialization now goes through `FabricService.export_canvas()`, which includes these properties.

## Repo fixes needed to run the test suite

- Fixed 12 spec files with broken import paths (suite did not compile).
- Fixed `dashboard.component.scss` importing `@oscc/app.component.scss` via `@import url(...)`, which webpack cannot resolve in the karma build.

## Tests

New unit tests for question validation, the add-question dialog and the fabric quiz logic (render, answer reveal, answer-once, serialization). `ng build` is green; the karma suite still has a pre-existing load error unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)